### PR TITLE
qemuriscv64: pin kernel to 4.15

### DIFF
--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -11,7 +11,7 @@ MACHINE_ARCH = "riscv64"
 KERNEL_IMAGETYPE = "vmlinux"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-riscv"
-PREFERRED_VERSION_linux-riscv = "4.16%"
+PREFERRED_VERSION_linux-riscv = "4.15%"
 
 GDBVERSION = "riscv"
 QEMUVERSION = "riscv"


### PR DESCRIPTION
The 4.16 kernel doesn't currently seem to be able to come up to a login
prompt. Set the default to 4.15 (which can) for the time-being.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>