### PR TITLE
WIC image support

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -27,3 +27,19 @@ RISCV_BBL_PAYLOAD ?= "${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin"
 INITRAMFS_IMAGE_BUNDLE = "1"
 INITRAMFS_IMAGE = "riscv-initramfs-image"
 KERNEL_INITRAMFS = '-initramfs'
+
+IMAGE_FSTYPES_append = " wic.gz"
+
+# Do not update fstab file when using wic images
+WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+
+IMAGE_BOOT_FILES = ""
+
+### wic default support
+WKS_FILE_DEPENDS ?= " \
+    riscv-pk \
+    e2fsprogs-native \
+    bmap-tools-native \
+"
+
+WKS_FILE ?= "freedom-u540-bbl.wks"

--- a/recipes-core/images/riscv-initramfs-image.bb
+++ b/recipes-core/images/riscv-initramfs-image.bb
@@ -16,3 +16,7 @@ IMAGE_ROOTFS_SIZE = "8192"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 
 BAD_RECOMMENDATIONS += "busybox-syslog"
+
+# WIC is not compatible with an initramfs image, also enabling WIC would cause
+# an circular dependency.
+IMAGE_FSTYPES_remove = " wic wic.gz"

--- a/wic/freedom-u540-bbl.wks
+++ b/wic/freedom-u540-bbl.wks
@@ -1,0 +1,6 @@
+# short-description: Create SD card image for HiFive Unleashed development board
+
+part bbl --source rawcopy --sourceparams="file=bbl.bin" --ondisk mmcblk --align 1 --part-type 2e54b353-1271-4842-806f-e436d6af6985
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096 --size 1G
+
+bootloader --ptable gpt


### PR DESCRIPTION
The WIC image is modeled after what is created in the Buildroot based freedom-u-sdk. The bbl.bin file is written to the first part and rootfs image is written to second.

WIC is enabled  by default on the freedom-u540 machine. `bbl.bin` will in this case be a Linux kernel with a bundled initramfs image and initially the rootfs part even if written will not be utilized but one can chroot to it once the initramfs boots. 

The image layout

```
$ fdisk -l free.img 

Disk free.img: 1.3 GiB, 1416853504 bytes, 2767292 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 18B6DAA8-A99C-4E14-9239-3D3A15D168F5

Device     Start     End Sectors  Size Type
free.img1     34   34867   34834   17M unknown
free.img2  40960 2767257 2726298  1.3G Linux filesystem
```

More detailed information about the different parts:
```
Partition number (1,2, default 2): 1

         Device: free.img1
          Start: 34
            End: 34867
        Sectors: 34834
           Size: 17M
           Type: unknown
      Type-UUID: 2E54B353-1271-4842-806F-E436D6AF6985
           UUID: E19CABF1-C66B-4BBA-BF75-0CBF4EE5AC1B
           Name: primary

Command (m for help): i2
Partition number (1,2, default 2): 2

         Device: free.img2
          Start: 40960
            End: 2767257
        Sectors: 2726298
           Size: 1,3G
           Type: Linux filesystem
      Type-UUID: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
           UUID: CF4A9840-F841-4EC0-B22D-22FD8488135A
           Name: root
```

Fixes #5 
