### PR TITLE
Cleanup MACHINE_ARCH overrides to fix machine-specific package collision

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -6,7 +6,6 @@
 require conf/machine/include/tune-riscv.inc
 
 MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
-MACHINE_ARCH = "riscv64"
 
 KERNEL_IMAGETYPE = "vmlinux"
 

--- a/conf/machine/include/tune-riscv.inc
+++ b/conf/machine/include/tune-riscv.inc
@@ -10,10 +10,10 @@ AVAILTUNES += "riscv64 riscv32"
 TUNE_FEATURES_tune-riscv64 = "riscv64 littleendian"
 TUNE_ARCH_tune-riscv64 = "riscv64"
 TUNE_PKGARCH_tune-riscv64 = "riscv64"
-PACKAGE_EXTRA_ARCHS_tune-riscv64 = ""
+PACKAGE_EXTRA_ARCHS_tune-riscv64 = "riscv64"
 
 TUNE_FEATURES_tune-riscv32 = "riscv32 littleendian"
 TUNE_ARCH_tune-riscv32 = "riscv32"
 TUNE_PKGARCH_tune-riscv32 = "riscv32"
-PACKAGE_EXTRA_ARCHS_tune-riscv32 = ""
+PACKAGE_EXTRA_ARCHS_tune-riscv32 = "riscv32"
 

--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -6,7 +6,6 @@ require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc
 
 MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
-MACHINE_ARCH = "riscv64"
 
 KERNEL_IMAGETYPE = "vmlinux"
 

--- a/conf/machine/riscv32.conf
+++ b/conf/machine/riscv32.conf
@@ -6,8 +6,6 @@ DEFAULTTUNE = "riscv32"
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc
 
-MACHINE_ARCH = "riscv32"
-
 PREFERRED_VERSION_qemu = "${QEMUVERSION}"
 PREFERRED_VERSION_qemu-native = "${QEMUVERSION}"
 PREFERRED_VERSION_nativesdk-qemu = "${QEMUVERSION}"

--- a/conf/machine/riscv64.conf
+++ b/conf/machine/riscv64.conf
@@ -6,8 +6,6 @@ DEFAULTTUNE = "riscv64"
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc
 
-MACHINE_ARCH = "riscv64"
-
 PREFERRED_VERSION_qemu = "${QEMUVERSION}"
 PREFERRED_VERSION_qemu-native = "${QEMUVERSION}"
 PREFERRED_VERSION_nativesdk-qemu = "${QEMUVERSION}"

--- a/recipes-devtools/riscv-tools/riscv-pk.bb
+++ b/recipes-devtools/riscv-tools/riscv-pk.bb
@@ -9,6 +9,8 @@ SRC_URI = "git://github.com/riscv/riscv-pk.git \
            file://0001-add-acinclude.m4.patch \
           "
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 LDFLAGS_append = " -Wl,--build-id=none"
 
 inherit autotools


### PR DESCRIPTION
Make sure that machine-specific packages are built separately for different machines.