### PR TITLE
machine: allow to override kernel's provider/version

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -9,8 +9,8 @@ MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
 
 KERNEL_IMAGETYPE = "vmlinux"
 
-PREFERRED_PROVIDER_virtual/kernel = "linux-riscv"
-PREFERRED_VERSION_linux-riscv = "4.15%"
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
+PREFERRED_VERSION_linux-riscv ?= "4.15%"
 
 GDBVERSION = "riscv"
 QEMUVERSION = "riscv"

--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -2,15 +2,15 @@
 #@NAME: generic riscv64 machine
 #@DESCRIPTION: Machine configuration for running a generic riscv64
 
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
+PREFERRED_VERSION_linux-riscv ?= "4.15%"
+
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc
 
 MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
 
 KERNEL_IMAGETYPE = "vmlinux"
-
-PREFERRED_PROVIDER_virtual/kernel = "linux-riscv"
-PREFERRED_VERSION_linux-riscv = "4.15%"
 
 GDBVERSION = "riscv"
 QEMUVERSION = "riscv"


### PR DESCRIPTION
It is useful to be able to override kernel's provider or version from
local.conf.

For qemuriscv64 machine move PREFERRED_* variables before qemu.inc,
because it sets PREFERRED_PROVIDER to linux-yocto.

Signed-off-by: Taras Kondratiuk <takondra@cisco.com>