### PR TITLE
recipes-devtools/rpm: Remove the beecrypt dependency

### DIFF
--- a/recipes-devtools/rpm/rpm_%.bbappend
+++ b/recipes-devtools/rpm/rpm_%.bbappend
@@ -1,3 +1,0 @@
-DEPENDS_append_class-target = " beecrypt"
-EXTRA_OECONF_append_class-target = " --with-crypto=beecrypt"
-


### PR DESCRIPTION
beecrypt is no longer included in OE-core (since fb8ca4225f beecrypt:
remove) so remove our dependency on it.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>