### PR TITLE
riscv-pk: depend on virtual/kernel:do_deploy

### DIFF
--- a/recipes-devtools/riscv-tools/riscv-pk.bb
+++ b/recipes-devtools/riscv-tools/riscv-pk.bb
@@ -21,7 +21,8 @@ INHIBIT_PACKAGE_STRIP = "1"
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "virtual/kernel"
+# bbl_payload needs kernel deployed artifacts (e.g. vmlinux)
+do_compile[depends] += "virtual/kernel:do_deploy"
 
 do_install_prepend () {
         install -d ${D}${datadir}/riscv-pk


### PR DESCRIPTION
bbl_payload requires the kernel deployed artifacts (e.g. vmlinux) during
compile time in order to generate the final bbl binary, so add
virtual/kernel:do_deploy as a do_compile dependency to get the
dependency task in the expected order.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>