### PR TITLE
gdb: Update to latest RISC-V fork

### DIFF
--- a/recipes-devtools/gdb/files/0001-linux-ptrace-Fix-RISC-V-cross-compilation-error.patch
+++ b/recipes-devtools/gdb/files/0001-linux-ptrace-Fix-RISC-V-cross-compilation-error.patch
@@ -1,0 +1,34 @@
+From 19422cdac7618e63e665329542e074c6f27e7ba4 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair.francis@wdc.com>
+Date: Fri, 13 Jul 2018 15:14:58 -0700
+Subject: [PATCH] linux-ptrace: Fix RISC-V cross compilation error
+
+To avoid this error:
+./gdb/nat/linux-ptrace.h:175:21: error: expected identifier      before '(' token
+      #define TRAP_HWBKPT (4)
+when cross compiling remove the #define.
+
+Signed-eff-by: Alistair Francis <alistair.francis@wdc.com>
+Upstream-status: Pending
+---
+ gdb/nat/linux-ptrace.h | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/gdb/nat/linux-ptrace.h b/gdb/nat/linux-ptrace.h
+index 59549452c0..7f102a31ec 100644
+--- a/gdb/nat/linux-ptrace.h
++++ b/gdb/nat/linux-ptrace.h
+@@ -171,10 +171,6 @@ struct buffer;
+ # define GDB_ARCH_IS_TRAP_HWBKPT(X) ((X) == TRAP_HWBKPT)
+ #endif
+ 
+-#ifndef TRAP_HWBKPT
+-# define TRAP_HWBKPT 4
+-#endif
+-
+ extern void linux_ptrace_attach_fail_reason (pid_t pid, struct buffer *buffer);
+ 
+ /* Find all possible reasons we could have failed to attach to PTID
+-- 
+2.17.1
+

--- a/recipes-devtools/gdb/gdb-riscv.inc
+++ b/recipes-devtools/gdb/gdb-riscv.inc
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \
                     file://COPYING3.LIB;md5=6a6a8e020838b23406c81b19c1d46df6 \
                     file://COPYING.LIB;md5=9f604d8a4f8e74f4f5140845a21b6674"
 
-SRCREV = "c025f0bed5fcb51fdd2e1e84cdc17ee562411f15"
-SRC_URI = "git://github.com/kraj/binutils-gdb;branch=oe/riscv;rebasable=1"
+SRCREV = "08e90a91f7ecf062b43cfadb425ff26536e6ee7b"
+SRC_URI = "git://github.com/riscv/riscv-binutils-gdb.git;branch=riscv-gdb-8.1"
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/gdb/gdb_riscv.bb
+++ b/recipes-devtools/gdb/gdb_riscv.bb
@@ -1,6 +1,8 @@
 require recipes-devtools/gdb/gdb.inc
 require gdb-${PV}.inc
 
+SRC_URI += "file://0001-linux-ptrace-Fix-RISC-V-cross-compilation-error.patch"
+
 inherit python3-dir
 
 EXTRA_OEMAKE_append_libc-musl = "\


### PR DESCRIPTION
Update to the latest RISC-V GDB and a patch to fix a compilation error

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>