### PR TITLE
qemuriscv64: uncomment accidentally commented out QEMUVERSION

### DIFF
--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -13,7 +13,7 @@ MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
 KERNEL_IMAGETYPE = "vmlinux"
 
 GDBVERSION = "riscv"
-#QEMUVERSION = "riscv"
+QEMUVERSION = "riscv"
 
 SERIAL_CONSOLES = "115200;ttyS0 115200;hvc0"
 


### PR DESCRIPTION
Looks like commit 2cf991cc3191 ("add templates for commits and issues")
accidentally commented out QEMUVERSION for qemuriscv64 machine. It
broke a build because default version of QEMU gets selected that doesn't
support RISC-V.

Uncomment it back.

Signed-off-by: Taras Kondratiuk <takondra@cisco.com>

