### PR TITLE
Update machine kernel version 4.18-rc7

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -10,7 +10,7 @@ MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
 KERNEL_IMAGETYPE = "vmlinux"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
-PREFERRED_VERSION_linux-riscv ?= "4.17%"
+PREFERRED_VERSION_linux-riscv ?= "4.18%"
 
 GDBVERSION = "riscv"
 QEMUVERSION = "riscv"

--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -3,7 +3,7 @@
 #@DESCRIPTION: Machine configuration for running a generic riscv64
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
-PREFERRED_VERSION_linux-riscv ?= "4.17%"
+PREFERRED_VERSION_linux-riscv ?= "4.18%"
 
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc

--- a/recipes-kernel/linux/linux-riscv_4.18.bb
+++ b/recipes-kernel/linux/linux-riscv_4.18.bb
@@ -2,7 +2,7 @@ require recipes-kernel/linux/linux-riscv-common.inc
 
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION ?= "4.17"
+LINUX_VERSION ?= "4.18-rc7"
 
 BRANCH = "riscv-all"
 SRCREV = "aef7a9cf2530c4ebabc0c6d2a64ee2100fc6b854"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.
Upgrade the kernel version from 4.17 to 4.18-rc7.
For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
--> 

**- <recipename>: Short log / Statement of what needed to be changed.**
Addresses issue #20
1. fix kernel sanity check.
2. upgrade to config file 4.17 to 4.18-rc7.
    - conf/machine/freedom-u540.conf
    - conf/machine/qemuriscv64.conf
3. upgrade to kernel bb file 4.17 to 4.18-rc7.
    - recipes-kernel/linux/linux-riscv_4.17.bb → recipes-kernel/linux/linux-riscv_4.18.bb  

**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  Update machine kernel version 4.18-rc7 and fix kernel sanity check error

**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: pino-kim <sungwon.pino@gmail.com>**

