### PR TITLE
Modified kernel bbrecipe commitID and Create Kenrel 4.14 bbrecipe

### DIFF
--- a/recipes-kernel/linux/linux-riscv_4.14.bb
+++ b/recipes-kernel/linux/linux-riscv_4.14.bb
@@ -1,0 +1,6 @@
+require recipes-kernel/linux/linux-riscv-common.inc
+
+LINUX_VERSION ?= "4.14"
+
+BRANCH = "riscv-linux-4.14"
+SRCREV = "c2d852cb2f3d1875389ed23ad41fbab541b9533b"

--- a/recipes-kernel/linux/linux-riscv_4.15.bb
+++ b/recipes-kernel/linux/linux-riscv_4.15.bb
@@ -3,4 +3,4 @@ require recipes-kernel/linux/linux-riscv-common.inc
 LINUX_VERSION ?= "4.15"
 
 BRANCH = "riscv-linux-4.15"
-SRCREV = "48fb45691946afe9a421d676513d4e623932dbd3"
+SRCREV = "fe92d7905c6ea0ebeabeb725b8040754ede7c220"

--- a/recipes-kernel/linux/linux-riscv_4.18.bb
+++ b/recipes-kernel/linux/linux-riscv_4.18.bb
@@ -2,7 +2,7 @@ require recipes-kernel/linux/linux-riscv-common.inc
 
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
-LINUX_VERSION ?= "4.18-rc7"
+LINUX_VERSION ?= "4.18"
 
-BRANCH = "riscv-all"
-SRCREV = "aef7a9cf2530c4ebabc0c6d2a64ee2100fc6b854"
+BRANCH = "riscv-linux-4.18"
+SRCREV = "33e7d0092ad14e012018327bdf4e904d62e71440"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
--> BuildPC OS is Ubuntu 16.04

**- <recipename>: Short log / Statement of what needed to be changed.**
  path: meta-riscv/recipes-kernel/linux/

1. modified kernel version 4.18-rc7 -> 4.18
    - My prior PR had kernel build issue. So change below link's commitID kernel build well.
RISC-V Updates for the 4.19 Merge Window
2. modified kernel 4.15 commitid. Because fetch error.
3. create kernel 4.14 bbrecipe.

**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
 Update kernel bbrecipe.  

**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

