### PR TITLE
Add support for booting u-boot on QEMU Virt machine

### DIFF
--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -20,9 +20,13 @@ TCLIBC = "glibc"
 IMAGE_FSTYPES_append = " ext4"
 
 MACHINE_EXTRA_RRECOMMENDS += " kernel-modules"
-EXTRA_IMAGEDEPENDS += "riscv-pk"
 
+EXTRA_IMAGEDEPENDS += "riscv-pk"
 RISCV_BBL_PAYLOAD ?= "${KERNEL_IMAGETYPE}"
+
+EXTRA_IMAGEDEPENDS += "u-boot"
+UBOOT_MACHINE = "qemu-riscv64_defconfig"
+UBOOT_ELF = "u-boot"
 
 # qemuboot options
 QB_KERNEL_CMDLINE_APPEND = "console=hvc0,115200"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,3 @@
+SRC_URI = "git://git.denx.de/u-boot-x86.git;branch=riscv-working"
+
+SRCREV = "0b6036bcfd4bd9d9ef7687db43a4573e48ad0836"


### PR DESCRIPTION
This patch series uses a fork of u-boot to boot u-boot on the QEMU RISC-V Virt machine.

The patch set is currently pending on upstream u-boot, the status is available here: https://marc.info/?l=u-boot&m=153664145925772&w=2

We don't really need to merge this just yet, I just wanted to have it ready for when the patches are merged.