### PR TITLE
Add systemd for distro init manager   (derived from #34 comment)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -72,7 +72,9 @@ require conf/distro/include/security_flags.inc
 
 INHERIT += "uninative"
 
-DISTRO_FEATURES_append = " largefile opengl ptest multiarch wayland pam "
+DISTRO_FEATURES_append = " largefile opengl ptest multiarch wayland pam  systemd "
+DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
+VIRTUAL-RUNTIME_init_manager = "systemd"
 HOSTTOOLS_NONFATAL_append = " ssh"
 EOF
 


### PR DESCRIPTION
distro append systemd for a init_manager

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
--> build well and boot well (by 'runqemu nographic') but stuck long time after bootup.
@kraj give me way to solve this. so append systemd for a init_manager and I can reach commandline.  

**- <recipename>: Short log / Statement of what needed to be changed.**
M: meta-riscv/setup.sh
  
**-(Optional pointers to external resources, such as defect tracking)**
All test is in Ubuntu 16.04 clI mode.(not gui).
  
**-Signed-off-by: pino-kim <sungwon.pino@gmail.com>**

