### PR TITLE
u-boot: Be mindful of other BSPs when it comes to u-boot overrides

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,3 +1,5 @@
-SRC_URI = "git://git.denx.de/u-boot-x86.git;branch=riscv-working"
+SRC_URI_riscv64 = "git://git.denx.de/u-boot-x86.git;branch=riscv-working;rebaseable=1"
 
-SRCREV = "0b6036bcfd4bd9d9ef7687db43a4573e48ad0836"
+SRCREV_riscv64  = "07985f7aedfc017f539fb1984d432497193121cb"
+
+COMPATIBLE_MACHINE_qemuriscv64 = "qemuriscv64"


### PR DESCRIPTION
We are sort of hijacking OE-Core recipe here, so lets be careful and
make it such that it only happens for risv64, which makes a multi-BSP
scenario work again.

This repo seems to be rebasing :( so add rebaseable=1 so bitbake knows
about it

update to latest rev as of today

Signed-off-by: Khem Raj <raj.khem@gmail.com>

