### PR TITLE
kernel : Update recent kernel commit ID and BB files

### DIFF
--- a/recipes-kernel/linux/linux-riscv_4.15.bb
+++ b/recipes-kernel/linux/linux-riscv_4.15.bb
@@ -1,6 +1,12 @@
 require recipes-kernel/linux/linux-riscv-common.inc
 
+SUMMARY = "RISC-V Community BSP RISC-V Linux kernel with backported features and fiexes"
+DESCRIPTION = "Linux kernel based on mainline kernel used by RISC-V Community BSP in order to \
+provide support for some backported features and fixes, or because it was applied in linux-next \
+and takes some time to become part of a stable version, or because it is not applicable for \
+upstreaming."
+
 LINUX_VERSION ?= "4.15"
 
 BRANCH = "riscv-linux-4.15"
-SRCREV = "fe92d7905c6ea0ebeabeb725b8040754ede7c220"
+SRCREV = "758d792057a2c0276844bc88e790f3ddabfc43ae"

--- a/recipes-kernel/linux/linux-riscv_4.18.bb
+++ b/recipes-kernel/linux/linux-riscv_4.18.bb
@@ -1,8 +1,14 @@
 require recipes-kernel/linux/linux-riscv-common.inc
 
+SUMMARY = "RISC-V Community BSP RISC-V Linux kernel with backported features and fiexes"
+DESCRIPTION = "Linux kernel based on mainline kernel used by RISC-V Community BSP in order to \
+provide support for some backported features and fixes, or because it was applied in linux-next \
+and takes some time to become part of a stable version, or because it is not applicable for \
+upstreaming."
+
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 LINUX_VERSION ?= "4.18"
 
 BRANCH = "riscv-linux-4.18"
-SRCREV = "33e7d0092ad14e012018327bdf4e904d62e71440"
+SRCREV = "dfeb52bf6e351d8d974889ff5e3e696cd4c8ab66"


### PR DESCRIPTION
I update  riscv-linux verion 4.15 and 4.18 kernel bbfile, head to recent
commit. And add SUMMAARY, DESCRIPTION field to provide imformation of
kernel bbfile.

update kernel bbfiles and add SUMMARY, DESCRIPTION field.

signed-off-by: pino-kim <sungwon.pino@gmail.com>
