### PR TITLE
qemuriscv64: Express u-boot bootloader choice

### DIFF
--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -5,6 +5,9 @@
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
 PREFERRED_VERSION_linux-riscv ?= "4.18%"
 
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
+PREFERRED_PROVIDER_u-boot ?= "u-boot"
+
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc
 


### PR DESCRIPTION
In a multi-BSP env u-boot may be provided by other BSP layers as well so
we need to be explicit about u-boot we need

Signed-off-by: Khem Raj <raj.khem@gmail.com>

