### PR TITLE
riscv-pk: Update to the latest version

### DIFF
--- a/recipes-devtools/riscv-tools/files/0002-Makefile.in-Don-t-specify-a-march-if-one-isn-t-speci.patch
+++ b/recipes-devtools/riscv-tools/files/0002-Makefile.in-Don-t-specify-a-march-if-one-isn-t-speci.patch
@@ -1,0 +1,39 @@
+From 4c0651d47ef53edf262c26e486543acb2b353cfb Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair.francis@wdc.com>
+Date: Fri, 2 Nov 2018 10:22:09 -0700
+Subject: [PATCH] Makefile.in: Don't specify a march if one isn't specified
+
+This breaks the build when using the OE toolchain.
+
+Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
+---
+ Makefile.in | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index aeabdc2..ac696fb 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -50,19 +50,6 @@ else
+   project_ver:=@PACKAGE_VERSION@
+ endif
+ 
+-# If --with-arch is not specified, it defaults to whatever the compiler's
+-# default is. The -with-abi is not necessary for this project. Unconditionally
+-# compile it with a no-float ABI. i.e., ilp32 for 32-bit and lp64 for 64-bit.
+-
+-ifeq (@WITH_ARCH@,)
+-  march := -march=$(shell @CC@ -v 2>&1 | \
+-                    sed 's/ /\n/g' | grep with-arch | awk -F= '{print $$2}')
+-else
+-  march := -march=@WITH_ARCH@
+-endif
+-is_32bit := $(findstring 32,$(march))
+-mabi := -mabi=$(if $(is_32bit),ilp32,lp64)
+-
+ # Installation directories
+ 
+ prefix       := @prefix@
+-- 
+2.19.1
+

--- a/recipes-devtools/riscv-tools/riscv-pk.bb
+++ b/recipes-devtools/riscv-tools/riscv-pk.bb
@@ -4,9 +4,10 @@ LICENSE = "GPLv2+"
 
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.GPLv2;md5=751419260aa954499f7abaabaa882bbe"
 
-SRCREV = "9d0911092df8e9bd483edf495a9a780e5f0e660f"
+SRCREV = "7bee30c1ff56975041ffc67cd0170d7477aba865"
 SRC_URI = "git://github.com/riscv/riscv-pk.git \
            file://0001-add-acinclude.m4.patch \
+           file://0002-Makefile.in-Don-t-specify-a-march-if-one-isn-t-speci.patch \
           "
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Update to the latest version of the RISC-V Proxy Kernel. This means we
are running an updated bbl.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
