### PR TITLE
u-boot: Remove RISC-V specific version

### DIFF
--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -6,7 +6,6 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
 PREFERRED_VERSION_linux-riscv ?= "4.19%"
 
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
-PREFERRED_PROVIDER_u-boot ?= "u-boot"
 
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,6 +1,0 @@
-# Remove patches applied in the common .bb
-SRC_URI_riscv64 = "git://git.denx.de/u-boot.git"
-
-SRCREV_riscv64  = "94228a9188803473206544c8f33649ea72bf1ee1"
-
-COMPATIBLE_MACHINE_qemuriscv64 = "qemuriscv64"


### PR DESCRIPTION
Now that u-boot 2018.11 is supported in Yocto we no longer need custom
options for RISC-V support.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
