### PR TITLE
libgpg-error: Add support for RISC-V 32-bit

### DIFF
--- a/recipes-support/libgpg-error/files/0001-syscfg-Add-a-riscv32-architecture.patch
+++ b/recipes-support/libgpg-error/files/0001-syscfg-Add-a-riscv32-architecture.patch
@@ -1,0 +1,61 @@
+From d1124a7b2aca0592088437f5e10917e4d3446c19 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair.francis@wdc.com>
+Date: Fri, 30 Nov 2018 09:15:54 -0800
+Subject: [PATCH Libgpg-error] syscfg: Add a riscv32 architecture.
+
+* src/syscfg/lock-obj-pub.riscv32-unknown-linux-gnu.h: New.
+* src/Makefile.am (lock_obj_pub): Add it.
+
+Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
+Signed-off-by: pino-kim <sungwon.pino@gmail.com>
+Upstream-Status: Pending
+---
+ src/Makefile.am                               |  1 +
+ .../lock-obj-pub.riscv32-unknown-linux-gnu.h  | 23 +++++++++++++++++++
+ 2 files changed, 24 insertions(+)
+ create mode 100644 src/syscfg/lock-obj-pub.riscv32-unknown-linux-gnu.h
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 8e6683f..ce1b882 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -67,6 +67,7 @@ lock_obj_pub = \
+ 	syscfg/lock-obj-pub.powerpc64le-unknown-linux-gnu.h \
+ 	syscfg/lock-obj-pub.powerpc-unknown-linux-gnuspe.h  \
+ 	syscfg/lock-obj-pub.riscv64-unknown-linux-gnu.h     \
++	syscfg/lock-obj-pub.riscv32-unknown-linux-gnu.h     \
+         syscfg/lock-obj-pub.s390x-unknown-linux-gnu.h       \
+         syscfg/lock-obj-pub.sh3-unknown-linux-gnu.h         \
+         syscfg/lock-obj-pub.sh4-unknown-linux-gnu.h         \
+diff --git a/src/syscfg/lock-obj-pub.riscv32-unknown-linux-gnu.h b/src/syscfg/lock-obj-pub.riscv32-unknown-linux-gnu.h
+new file mode 100644
+index 0000000..b5bdaf5
+--- /dev/null
++++ b/src/syscfg/lock-obj-pub.riscv32-unknown-linux-gnu.h
+@@ -0,0 +1,23 @@
++## lock-obj-pub.riscv32-unknown-linux-gnu.h
++## File created by gen-posix-lock-obj - DO NOT EDIT
++## To be included by mkheader into gpg-error.h
++
++typedef struct
++{
++  long _vers;
++  union {
++    volatile char _priv[24];
++    long _x_align;
++    long *_xp_align;
++  } u;
++} gpgrt_lock_t;
++
++#define GPGRT_LOCK_INITIALIZER {1,{{0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0}}}
++##
++## Local Variables:
++## mode: c
++## buffer-read-only: t
++## End:
++##
+-- 
+2.19.1
+

--- a/recipes-support/libgpg-error/libgpg-error_%.bbappend
+++ b/recipes-support/libgpg-error/libgpg-error_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append_riscv32 = "\
+    file://0001-syscfg-Add-a-riscv32-architecture.patch \
+"


### PR DESCRIPTION
This adds support for 32-bit builds to libgpg-error. Upstream status is pending company approval.

Thanks for @pino-kim for helping figure out the patch.