### PR TITLE
riscv-pk: Bump to the latest version

### DIFF
--- a/recipes-devtools/riscv-tools/riscv-pk.bb
+++ b/recipes-devtools/riscv-tools/riscv-pk.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2+"
 
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.GPLv2;md5=751419260aa954499f7abaabaa882bbe"
 
-SRCREV = "6ebd0f2a46255d0c76dad3c05b16c1d154795d26"
+SRCREV = "92434c4f697564929f2ceb724bc82d3b6bc58879"
 SRC_URI = "git://github.com/riscv/riscv-pk.git \
            file://0001-add-acinclude.m4.patch \
           "


### PR DESCRIPTION
Bump to the latest bbl version, this fixes the warnings printed by QEMU
on boot.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>