### PR TITLE
machine: Rename the baremetal machines

### DIFF
--- a/conf/machine/baremetal-riscv32.conf
+++ b/conf/machine/baremetal-riscv32.conf
@@ -6,10 +6,6 @@ DEFAULTTUNE = "riscv32"
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc
 
-PREFERRED_VERSION_qemu = "${QEMUVERSION}"
-PREFERRED_VERSION_qemu-native = "${QEMUVERSION}"
-PREFERRED_VERSION_nativesdk-qemu = "${QEMUVERSION}"
-
 GDBVERSION = "riscv"
 
 # qemuboot options

--- a/conf/machine/baremetal-riscv64.conf
+++ b/conf/machine/baremetal-riscv64.conf
@@ -6,10 +6,6 @@ DEFAULTTUNE = "riscv64"
 require conf/machine/include/qemu.inc
 require conf/machine/include/tune-riscv.inc
 
-PREFERRED_VERSION_qemu = "${QEMUVERSION}"
-PREFERRED_VERSION_qemu-native = "${QEMUVERSION}"
-PREFERRED_VERSION_nativesdk-qemu = "${QEMUVERSION}"
-
 GDBVERSION = "riscv"
 
 # qemuboot options


### PR DESCRIPTION
The baremetal machines can't be built as bitbake complains about
riscv32/riscv64 being included twice in the PACKAGE_ARCH variable. To
fix this rename the machines to be different from the architecture.

Also remove the QEMU overrides as these are no longer required.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>