### PR TITLE
qemu : Usermode fails with invalid instruction error (for riscv32)

### DIFF
--- a/conf/machine/include/arch-riscv.inc
+++ b/conf/machine/include/arch-riscv.inc
@@ -6,3 +6,5 @@ TUNE_ARCH = "${TUNE_ARCH_tune-${DEFAULTTUNE}}"
 TUNE_PKGARCH = "${TUNE_PKGARCH_tune-${DEFAULTTUNE}}"
 TUNE_CCARGS .= ""
 
+# QEMU usermode fails with invalid instruction error (For riscv32)
+MACHINE_FEATURES_BACKFILL_CONSIDERED_append = "${@bb.utils.contains('TUNE_FEATURES', 'riscv32', ' qemu-usermode', '', d)}"


### PR DESCRIPTION
- backport for riscv arch
- Usermode fails with invalid instruction error (for riscv32)

Signed-off-by: pino-kim <sungwon.pino@gmail.com>
