### PR TITLE
gdb-cross-canadian: Add bison-native dependency

### DIFF
--- a/recipes-devtools/gdb/gdb-cross-canadian_riscv.bb
+++ b/recipes-devtools/gdb/gdb-cross-canadian_riscv.bb
@@ -1,3 +1,5 @@
 require recipes-devtools/gdb/gdb-common.inc
 require recipes-devtools/gdb/gdb-cross-canadian.inc
 require gdb-${PV}.inc
+
+DEPENDS += "bison-native"


### PR DESCRIPTION
This is needed when building gdb from git, in OE-core gdb is built from
tarballs where this issue is not seen, so keep this fix local here

Signed-off-by: Khem Raj <raj.khem@gmail.com>

