### PR TITLE
qemuriscv64: Don't use the linux-riscv kernel

### DIFF
--- a/conf/machine/include/qemuriscv.inc
+++ b/conf/machine/include/qemuriscv.inc
@@ -1,6 +1,3 @@
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
-PREFERRED_VERSION_linux-riscv ?= "4.19%"
-
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 
 require conf/machine/include/qemu.inc

--- a/conf/machine/qemuriscv32.conf
+++ b/conf/machine/qemuriscv32.conf
@@ -6,6 +6,10 @@ require conf/machine/include/qemuriscv.inc
 
 DEFAULTTUNE = "riscv32"
 
+# The mainline 4.19 kernel doesn't compile for 32-bit RISC-V
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
+PREFERRED_VERSION_linux-riscv ?= "4.19%"
+
 # u-boot doesn't compile, error: "can't link hard-float modules with soft-float modules"
 # EXTRA_IMAGEDEPENDS += "u-boot"
 # UBOOT_MACHINE = "qemu-riscv32_defconfig"

--- a/recipes-kernel/linux/linux-yocto_4.19.bbappend
+++ b/recipes-kernel/linux/linux-yocto_4.19.bbappend
@@ -1,0 +1,1 @@
+COMPATIBLE_MACHINE_append = "|qemuriscv64"


### PR DESCRIPTION
Default to the mainline 4.19 kernel for the 64-bit QEMU machine.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>