### PR TITLE
qemuriscv64.conf: Pin to linux-riscv again

### DIFF
--- a/conf/machine/qemuriscv64.conf
+++ b/conf/machine/qemuriscv64.conf
@@ -7,3 +7,6 @@ require conf/machine/include/qemuriscv.inc
 EXTRA_IMAGEDEPENDS += "u-boot"
 UBOOT_MACHINE = "qemu-riscv64_defconfig"
 UBOOT_ELF = "u-boot"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-riscv"
+PREFERRED_VERSION_linux-riscv = "4.19%"


### PR DESCRIPTION
linux-yocto hangs before it reaches console, until that is
fixed we can not switch

Signed-off-by: Khem Raj <raj.khem@gmail.com>

