### PR TITLE
freedom-u540: Don't hardcode linux-version

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -11,7 +11,6 @@ MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
 KERNEL_IMAGETYPE = "Image"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-riscv"
-PREFERRED_VERSION_linux-riscv ?= "5.0%"
 
 GDBVERSION = "riscv"
 


### PR DESCRIPTION
Don't hardcode the Linux version to make it easier to overwrite the
Linux provider. There is only one linux-riscv version so it is not
required.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
