### PR TITLE
linux-mainline: Fix kernel version checks

### DIFF
--- a/recipes-kernel/linux/linux-mainline_5.1.bb
+++ b/recipes-kernel/linux/linux-mainline_5.1.bb
@@ -1,6 +1,7 @@
 require recipes-kernel/linux/linux-mainline-common.inc
 
-LINUX_VERSION ?= "5.1"
+LINUX_VERSION ?= "5.1.x"
+KERNEL_VERSION_SANITY_SKIP="1"
 
 BRANCH = "linux-5.1.y"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
Fix the linux-mainline kernel version checks now that we are using
5.1.1.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
