### PR TITLE
u-boot: Fix UBOOT_ENTRYPOINT variable setting

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -38,6 +38,8 @@ WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 EXTRA_IMAGEDEPENDS += "u-boot"
 UBOOT_MACHINE = "sifive_fu540_defconfig"
 
+UBOOT_ENTRYPOINT = "0x80200000"
+
 # Set this to "tftp-boot" to generate a boot.scr file which should
 #  be included in the TFTP directory. It will contain the commands to
 #  autoboot Linux from u-boot.

--- a/recipes-bsp/u-boot/u-boot_2019.04.bbappend
+++ b/recipes-bsp/u-boot/u-boot_2019.04.bbappend
@@ -24,8 +24,6 @@ SRC_URI += "file://0001-riscv-add-infrastructure-for-calling-functions-on-ot.pat
 
 DEPENDS += "u-boot-tools-native"
 
-UBOOT_ENTRYPOINT = "0x80200000"
-
 # Overwrite this for your server
 TFTP_SERVER_IP ?= "127.0.0.1"
 
@@ -33,7 +31,7 @@ do_configure_prepend() {
     sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${S}/include/configs/sifive-fu540.h
 
     if [ -f "${WORKDIR}/${UBOOT_ENV}.txt" ]; then
-        mkimage -A arm -O linux -T script -C none -n "U-Boot boot script" \
+        mkimage -O linux -T script -C none -n "U-Boot boot script" \
             -d ${WORKDIR}/${UBOOT_ENV}.txt ${WORKDIR}/boot.scr.uimg
     fi
 }


### PR DESCRIPTION
Ensure that UBOOT_ENTRYPOINT is set correctly for the HiFive Unleased.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
