### PR TITLE
Prepare for the Linux 5.2 upgrade

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -14,14 +14,14 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
 EXTRA_IMAGEDEPENDS += "opensbi"
 RISCV_SBI_PLAT = "sifive/fu540"
 
-# When we have u-boot SD/MMC load support we can swap to
-#  u-boot being the defual. Until then it's an option for TFTP boot
+## When we have u-boot SD/MMC load support we can swap to
+##  u-boot being the defual. Until then it's an option for TFTP boot
 # RISCV_SBI_PAYLOAD ?= "u-boot.bin"
-# This will set the kernel as the OpenSBI payload
+## This will set the kernel as the OpenSBI payload
 RISCV_SBI_PAYLOAD ?= "${KERNEL_IMAGETYPE}-${MACHINE}.bin"
 
-# Override the DTB from the firmware with this one from openSBI
-# Use this to add Microsemi Expansion board support
+## Override the DTB from the firmware with this one from openSBI
+## Use this to add Microsemi Expansion board support
 # RISCV_SBI_FDT ?= "HiFiveUnleashed-MicroSemi-Expansion.dtb"
 
 SERIAL_CONSOLES = "115200;ttySIF0"
@@ -32,7 +32,7 @@ IMAGE_FSTYPES_append = " wic.gz ext4"
 KERNEL_IMAGETYPES += "uImage"
 KEEPUIMAGE = "no"
 
-# Do not update fstab file when using wic images
+## Do not update fstab file when using wic images
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 
 EXTRA_IMAGEDEPENDS += "u-boot"
@@ -40,12 +40,12 @@ UBOOT_MACHINE = "sifive_fu540_defconfig"
 
 UBOOT_ENTRYPOINT = "0x80200000"
 
-# Set this to "tftp-boot" to generate a boot.scr file which should
-#  be included in the TFTP directory. It will contain the commands to
-#  autoboot Linux from u-boot.
+## Set this to "tftp-boot" to generate a boot.scr file which should
+##  be included in the TFTP directory. It will contain the commands to
+##  autoboot Linux from u-boot.
 UBOOT_ENV ?= "tftp-boot"
 
-### wic default support
+## wic default support
 WKS_FILE_DEPENDS ?= " \
     opensbi \
     e2fsprogs-native \

--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -53,6 +53,7 @@ WKS_FILE_DEPENDS ?= " \
 "
 
 IMAGE_BOOT_FILES ?= " \
+    fw_payload.bin \
     Image \
     uImage \
     boot.scr.uimg \

--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -55,6 +55,7 @@ WKS_FILE_DEPENDS ?= " \
 IMAGE_BOOT_FILES ?= " \
     Image \
     uImage \
+    boot.scr.uimg \
 "
 
 WKS_FILE ?= "freedom-u540-opensbi.wks"

--- a/wic/freedom-u540-opensbi.wks
+++ b/wic/freedom-u540-opensbi.wks
@@ -1,7 +1,7 @@
 # short-description: Create SD card image for HiFive Unleashed development board
 
-part opensbi --source rawcopy --sourceparams="file=fw_payload.bin" --ondisk mmcblk0 --size 32M --align 1 --part-type 2e54b353-1271-4842-806f-e436d6af6985
 part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --size=100M --align 4096
+part opensbi --source rawcopy --sourceparams="file=fw_payload.bin" --ondisk mmcblk0 --size 32M --align 1 --part-type 2e54b353-1271-4842-806f-e436d6af6985
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096 --size 5G
 
 bootloader --ptable gpt


### PR DESCRIPTION
These are patches that do some prepwork for the Linux 5.2, U-Boot 2019.07 and OpenSB 0.4 upgrade. This just does some cleanup in the ``freedom-u540.conf`` file, includes more binaries on the /boot partition and changes the Unleashed boot partition order.