### PR TITLE
Add meta-python before meta-multimedia

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,8 +41,8 @@ export BASH_SOURCE="openembedded-core/oe-init-build-env"
 # add the missing layers
 echo "Adding layers"
 bitbake-layers add-layer ../meta-openembedded/meta-oe
-bitbake-layers add-layer ../meta-openembedded/meta-multimedia
 bitbake-layers add-layer ../meta-openembedded/meta-python
+bitbake-layers add-layer ../meta-openembedded/meta-multimedia
 bitbake-layers add-layer ../meta-openembedded/meta-networking
 bitbake-layers add-layer ../meta-riscv
 


### PR DESCRIPTION
meta-multimedia depends on meta-python.  I'm not sure why it's
necessary to add all the dependent layers in order, but if I don't do
this I get a bunch of exceptions during setup.sh that result in no
meta-python in my bblayers.conf and thus a non-functional bitbake.

setup.sh was already explicitly adding meta-python, so this patch just
adds it before meta-multimedia.  That fixes the errors on my side.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>