### PR TITLE
freedom-u540: set UBOOT_DTB_LOADADDRESS

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -39,6 +39,7 @@ EXTRA_IMAGEDEPENDS += "u-boot"
 UBOOT_MACHINE = "sifive_fu540_defconfig"
 
 UBOOT_ENTRYPOINT = "0x80200000"
+UBOOT_DTB_LOADADDRESS = "0x82200000"
 
 ## Set this to "mmc-boot" to generate a boot.scr file which should be included
 ##  in the boot partition. It will try to load a kernel image by TFTP and if that


### PR DESCRIPTION
Based on the default u-boot machine configuration, useful for fitImage
support (known address for loading the device-tree).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>