### PR TITLE
freedom-u540: prefer += instead of append for IMAGE_FSTYPES

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -28,7 +28,7 @@ SERIAL_CONSOLES = "115200;ttySIF0"
 
 MACHINE_EXTRA_RRECOMMENDS += " kernel-modules"
 
-IMAGE_FSTYPES_append = " wic.gz ext4"
+IMAGE_FSTYPES += " wic.gz ext4"
 KERNEL_IMAGETYPES += "uImage"
 KEEPUIMAGE = "no"
 


### PR DESCRIPTION
Append causes IMAGE_FSTYPES to contaminate initramfs-based images, as
even when forcing it to be empty at the recipe level, it always shows up
after parsing.

Using += allows the recipe to set another value without being influenced
by the machine configuration.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>