### PR TITLE
u-boot: Add OSTree uEnx.txt.in file

### DIFF
--- a/recipes-bsp/u-boot/files/uEnv.txt
+++ b/recipes-bsp/u-boot/files/uEnv.txt
@@ -1,0 +1,4 @@
+bootcmd_otenv=load ${devtype} ${devnum}:3 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize}
+bootcmd_load_f=load ${devtype} ${devnum}:3 ${ramdisk_addr_r} "/boot"${kernel_image}
+bootcmd_run=bootm ${ramdisk_addr_r}
+bootcmd=run bootcmd_otenv; run bootcmd_load_f; run bootcmd_run

--- a/recipes-bsp/u-boot/u-boot_2019.07.bbappend
+++ b/recipes-bsp/u-boot/u-boot_2019.07.bbappend
@@ -25,6 +25,8 @@ SRC_URI_append_freedom-u540 = " \
             file://tftp-mmc-boot.txt \
            "
 
+SRC_URI_append_freedom-u540_sota = " file://uEnv.txt"
+
 DEPENDS_append_freedom-u540 = " u-boot-tools-native"
 
 # Overwrite this for your server
@@ -43,6 +45,11 @@ do_deploy_append_freedom-u540() {
     if [ -f "${WORKDIR}/boot.scr.uimg" ]; then
         install -d ${DEPLOY_DIR_IMAGE}
         install -m 755 ${WORKDIR}/boot.scr.uimg ${DEPLOY_DIR_IMAGE}
+    fi
+
+    if [ -f "${WORKDIR}/uEnv.txt" ]; then
+        install -d ${DEPLOY_DIR_IMAGE}
+        install -m 755 ${WORKDIR}/uEnv.txt ${DEPLOY_DIR_IMAGE}
     fi
 }
 


### PR DESCRIPTION
Add the uEnx.txt.in file to meta-riscv to allow users to build OSTree
setups for the HiFive Unleashed. This is based on the original version
from Ricardo Salveti (@ricardosalveti).

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>