### PR TITLE
glibc: Fix the glibc SRCREV

### DIFF
--- a/recipes-core/glibc/glibc_%.bbappend
+++ b/recipes-core/glibc/glibc_%.bbappend
@@ -3,4 +3,4 @@
 # This is the most recent port sent to the glibc mailing list
 GLIBC_GIT_URI_qemuriscv32 = "git://github.com/riscv/riscv-glibc.git"
 SRCBRANCH_qemuriscv32 = "riscv-glibc-2.29"
-SRCREV_qemuriscv32 = "06983fe52cfe8e4779035c27e8cc5d2caab31531"
+SRCREV_glibc_qemuriscv32 = "06983fe52cfe8e4779035c27e8cc5d2caab31531"


### PR DESCRIPTION
Now that OE is using glibc 2.30 and the SRCREV_glibc variable we need to
update our SRCREV.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>