### PR TITLE
riscv: Enable SECURITY_CFLAGS and GLIBC PIE for rv32/rv64

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,13 +16,3 @@ BBFILES_DYNAMIC += " \
 "
 
 LAYERSERIES_COMPAT_riscv-layer = "warrior"
-
-# risc-v does not get along with pie for reasons in so far not looked into
-SECURITY_CFLAGS_riscv64 = ""
-SECURITY_CFLAGS_pn-libgcc_riscv64 = ""
-#GCCPIE_riscv64 = ""
-GLIBCPIE_riscv64 = ""
-SECURITY_CFLAGS_riscv32 = ""
-SECURITY_CFLAGS_pn-libgcc_riscv32 = ""
-GCCPIE_riscv32 = ""
-GLIBCPIE_riscv32 = ""


### PR DESCRIPTION
GCC PIE works fine

Signed-off-by: Khem Raj <raj.khem@gmail.com>

