### PR TITLE
machine/qemuriscv32: Remove device loader

### DIFF
--- a/conf/machine/qemuriscv32.conf
+++ b/conf/machine/qemuriscv32.conf
@@ -6,8 +6,6 @@ require conf/machine/include/riscv/qemuriscv.inc
 
 DEFAULTTUNE = "riscv32"
 
-QB_OPT_APPEND += "-show-cursor -monitor null -device loader,file=${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE},addr=0x80400000"
-
 # u-boot doesn't compile, error: "can't link hard-float modules with soft-float modules"
 # EXTRA_IMAGEDEPENDS += "u-boot"
 # UBOOT_MACHINE = "qemu-riscv32_defconfig"


### PR DESCRIPTION
Now that we are using QEMU 4.1 we can use QEMU's -bios option and
-kernel option and remove the device loader.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>