### PR TITLE
setup.sh: Do not delete build dir

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,10 +6,6 @@ MACHINE="qemuriscv64"
 CONFFILE="conf/auto.conf"
 BITBAKEIMAGE="core-image-full-cmdline"
 
-# clean up the output dir
-echo "Cleaning build dir"
-rm -rf $DIR
-
 # make sure sstate is there
 #echo "Creating sstate directory"
 #mkdir -p ~/sstate/$MACHINE


### PR DESCRIPTION
When building in a non CI env this all is not
needed as the user might accidentally end up losing all the build
artifacts that are not intendeed to. On CI systems its better to delete
it via extra step outside setup

Signed-off-by: Khem Raj <raj.khem@gmail.com>

