### PR TITLE
openocd: Use the RISC-V fork

### DIFF
--- a/conf/machine/baremetal-riscv32.conf
+++ b/conf/machine/baremetal-riscv32.conf
@@ -6,6 +6,9 @@ DEFAULTTUNE = "riscv32"
 require conf/machine/include/qemu.inc
 require conf/machine/include/riscv/tune-riscv.inc
 
+PREFERRED_VERSION_openocd-native = "riscv"
+PREFERRED_VERSION_openocd = "riscv"
+
 # qemuboot options
 QB_MACHINE = "-machine virt"
 QB_DEFAULT_KERNEL = "fw_payload.elf"

--- a/conf/machine/baremetal-riscv64.conf
+++ b/conf/machine/baremetal-riscv64.conf
@@ -6,6 +6,9 @@ DEFAULTTUNE = "riscv64"
 require conf/machine/include/qemu.inc
 require conf/machine/include/riscv/tune-riscv.inc
 
+PREFERRED_VERSION_openocd-native = "riscv"
+PREFERRED_VERSION_openocd = "riscv"
+
 # qemuboot options
 QB_MACHINE = "-machine virt"
 QB_DEFAULT_KERNEL = "fw_payload.elf"

--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -12,6 +12,9 @@ KERNEL_IMAGETYPE = "fitImage"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
 
+PREFERRED_VERSION_openocd-native = "riscv"
+PREFERRED_VERSION_openocd = "riscv"
+
 EXTRA_IMAGEDEPENDS += "opensbi"
 RISCV_SBI_PLAT = "sifive/fu540"
 

--- a/conf/machine/qemuriscv32.conf
+++ b/conf/machine/qemuriscv32.conf
@@ -6,6 +6,9 @@ require conf/machine/include/riscv/qemuriscv.inc
 
 DEFAULTTUNE = "riscv32"
 
+PREFERRED_VERSION_openocd-native = "riscv"
+PREFERRED_VERSION_openocd = "riscv"
+
 # u-boot doesn't compile, error: "can't link hard-float modules with soft-float modules"
 # EXTRA_IMAGEDEPENDS += "u-boot"
 # UBOOT_MACHINE = "qemu-riscv32_smode_defconfig"

--- a/recipes-devtools/openocd/openocd_riscv.bb
+++ b/recipes-devtools/openocd/openocd_riscv.bb
@@ -1,0 +1,10 @@
+require recipes-devtools/openocd/openocd_git.bb
+
+SRC_URI = " \
+    git://github.com/riscv/riscv-openocd.git;protocol=http;branch=riscv;name=openocd \
+    git://repo.or.cz/r/git2cl.git;protocol=http;destsuffix=tools/git2cl;name=git2cl \
+    git://repo.or.cz/r/jimtcl.git;protocol=http;destsuffix=git/jimtcl;name=jimtcl \
+    git://repo.or.cz/r/libjaylink.git;protocol=http;destsuffix=git/src/jtag/drivers/libjaylink;name=libjaylink \
+"
+
+SRCREV_openocd = "f93ede5401c711e55d9852986aa399c0318efb22"


### PR DESCRIPTION
We currently need the RISC-V fork of OpenOCD.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>