### PR TITLE
openocd: Enable remote bitbang

### DIFF
--- a/recipes-devtools/openocd/openocd_riscv.bb
+++ b/recipes-devtools/openocd/openocd_riscv.bb
@@ -8,3 +8,5 @@ SRC_URI = " \
 "
 
 SRCREV_openocd = "f93ede5401c711e55d9852986aa399c0318efb22"
+
+EXTRA_OECONF_append = " --enable-remote-bitbang"


### PR DESCRIPTION
Enable remote bitbang to allow connecting OpenOCD to Verilator.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>