### PR TITLE
qemuriscv32: Use linux-yocto-dev for now

### DIFF
--- a/conf/machine/qemuriscv32.conf
+++ b/conf/machine/qemuriscv32.conf
@@ -9,6 +9,8 @@ DEFAULTTUNE = "riscv32"
 PREFERRED_VERSION_openocd-native = "riscv"
 PREFERRED_VERSION_openocd = "riscv"
 
+PREFERRED_PROVIDER_virtual/kernel = "linux-yocto-dev"
+
 # u-boot doesn't compile, error: "can't link hard-float modules with soft-float modules"
 # EXTRA_IMAGEDEPENDS += "u-boot"
 # UBOOT_MACHINE = "qemu-riscv32_smode_defconfig"

--- a/recipes-core/packagegroups/packagegroup-core-tools-debug.bbappend
+++ b/recipes-core/packagegroups/packagegroup-core-tools-debug.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+RDEPENDS_${PN}_remove_riscv32 = "strace"
+


### PR DESCRIPTION
Latest glibc wants kernel 5.4+ ABI and linux-yocto is still at 5.2, so
until that switches to 5.4 lets pin to dev kernel which is 5.5+

Fixes #199

Signed-off-by: Khem Raj <raj.khem@gmail.com>

