### PR TITLE
go-riscv: Delete 0009-ld-replace-glibc-dynamic-linker-with-musl.patch…

### DIFF
--- a/recipes-devtools/go/go-riscv.inc
+++ b/recipes-devtools/go/go-riscv.inc
@@ -18,7 +18,6 @@ SRC_URI_riscv64 = "\
     \
     file://0010-cmd-go-make-content-based-hash-generation-less-pedan.patch \
 "
-SRC_URI_append_riscv64_libc-musl = " file://0009-ld-replace-glibc-dynamic-linker-with-musl.patch"
 
 S_riscv64 = "${WORKDIR}/git"
 


### PR DESCRIPTION
… duplication

Core applies this patch via a bbappend too, so no need to apply here

Signed-off-by: Khem Raj <raj.khem@gmail.com>

