### PR TITLE
layer.conf: Skip textrel for eudev on rv64

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -20,3 +20,5 @@ BBFILES_DYNAMIC += " \
 "
 
 LAYERSERIES_COMPAT_riscv-layer = "warrior zeus dunfell"
+
+INSANE_SKIP_${MLPREFIX}eudev_riscv64 = "textrel"


### PR DESCRIPTION
Build QA complains
ERROR: eudev-3.2.9-r0 do_package_qa: QA Issue: eudev: ELF binary /usr/bin/udevadm has relocations in .text
eudev: ELF binary /usr/libexec/udevadm has relocations in .text [textrel]

Signed-off-by: Khem Raj <raj.khem@gmail.com>
