### PR TITLE
freedom-u540.conf: Define virtual/bootloader to be u-boot

### DIFF
--- a/conf/machine/freedom-u540.conf
+++ b/conf/machine/freedom-u540.conf
@@ -11,6 +11,7 @@ KERNEL_CLASSES = "kernel-fitimage"
 KERNEL_IMAGETYPE = "fitImage"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot"
 
 PREFERRED_VERSION_openocd-native = "riscv"
 PREFERRED_VERSION_openocd = "riscv"


### PR DESCRIPTION
Fixes
NOTE: Multiple providers are available for virtual/bootloader (u-boot, u-boot-juno, u-boot-orangepi-i96, u-boot-poplar, u-boot-socfpga)
Consider defining a PREFERRED_PROVIDER entry to match virtual/bootloader

Signed-off-by: Khem Raj <raj.khem@gmail.com>