### PR TITLE
openocd: Update to the latest SHA

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/openocd/openocd_riscv.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/openocd/openocd_riscv.bb
@@ -11,4 +11,4 @@ SRC_URI = " \
 
 SRCREV_openocd = "4f9e2d7171f3cad8d1a99dff3eee5ec5e6d8ea2b"
 
-COMPATIBLE_HOST = "(riscv32|riscv64).*-linux"
+COMPATIBLE_HOST = "(x86_64.*|i.86.*|riscv32|riscv64).*-linux"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/openocd/openocd_riscv.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/openocd/openocd_riscv.bb
@@ -9,6 +9,6 @@ SRC_URI = " \
     git://repo.or.cz/r/libjaylink.git;protocol=http;destsuffix=git/src/jtag/drivers/libjaylink;name=libjaylink \
 "
 
-SRCREV_openocd = "f93ede5401c711e55d9852986aa399c0318efb22"
+SRCREV_openocd = "4f9e2d7171f3cad8d1a99dff3eee5ec5e6d8ea2b"
 
 COMPATIBLE_HOST = "(riscv32|riscv64).*-linux"


### PR DESCRIPTION
Update the RISC-V fork of OpenOCD to the SHA.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>