### PR TITLE
glibc: Update to a later patch version

### DIFF
--- a/recipes-core/glibc/glibc_%.bbappend
+++ b/recipes-core/glibc/glibc_%.bbappend
@@ -1,8 +1,12 @@
 # Upstream Glibc does not yet have RISC-V 32-bit support
 
 GLIBC_GIT_URI_qemuriscv32 = "git://github.com/alistair23/glibc.git"
-SRCBRANCH_qemuriscv32 = "alistair/rv32.rfc6"
-SRCREV_glibc_qemuriscv32 = "7b2b52134a71129afa53fcb24144144a2c4ff406"
+SRCBRANCH_qemuriscv32 = "alistair/rv32.2.32"
+SRCREV_glibc_qemuriscv32 = "b3ef7a831e6e80d44ea36a9712395b3eda076b82"
 
 SRC_URI_remove_qemuriscv32 = " \
+	file://0016-Add-unused-attribute.patch \
+	file://0028-inject-file-assembly-directives.patch \
+	file://CVE-2020-6096.patch \
+	file://CVE-2020-6096_2.patch \
 "


### PR DESCRIPTION
Update the glibc RV32 to a more recent patch version. Remove some
backported patches that don't apply as we already have them merged.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
