### PR TITLE
README.md : Remove LSB related content that is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,6 @@ A console-only image for the 64-bit QEMU machine
 MACHINE=qemuriscv64 bitbake core-image-full-cmdline
 ```
 
-Basic image without X support suitable for Linux Standard Base (LSB) implementations.
-It includes the full meta-toolchain, plus development headers and libraries to form
-a standalone (on device) SDK for the 32-bit QEMU machine
-
-```text
-MACHINE=qemuriscv32 bitbake core-image-lsb-sdk
-```
-
 To build an image to run on the HiFive Unleashed using Wayland run the following
 
 ```text


### PR DESCRIPTION
No longer support Linux Standard Base (LSB) since version 3.0
core-image-lsb-sdk recipes are removed
So remove the related content

https://www.yoctoproject.org/docs/3.0/ref-manual/ref-manual.html#migration-3.0-lsb-support-removed

Signed-off-by: sungwon.pino <sungwon.pino@gmail.com>