### PR TITLE
Use https URLs to fetch repositories

### DIFF
--- a/tools/manifests/riscv-yocto.xml
+++ b/tools/manifests/riscv-yocto.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <manifest>
-  <remote name="openembedded" fetch="git://github.com/openembedded/" />
-  <remote name="riscv" fetch="git://github.com/riscv/" />
-  <remote name="yocto" fetch="git://git.yoctoproject.org/" />
+  <remote name="openembedded" fetch="https://github.com/openembedded/" />
+  <remote name="riscv" fetch="https://github.com/riscv/" />
   <default remote="openembedded" revision="master" />
 
   <project name="meta-riscv" remote="riscv" path="meta-riscv" revision="master" />


### PR DESCRIPTION
The git:// URLs currently used provide no protection against MITM.

Signed-off-by: Stefan O'Rear <sorear@fastmail.com>
