### PR TITLE
qt5-layer: Remove Qt5 overides

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,8 +10,6 @@ BBFILE_PATTERN_riscv-layer = "^${LAYERDIR}/"
 BBFILE_PRIORITY_riscv-layer = "6"
 
 BBFILES_DYNAMIC += " \
-    qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
-    qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
     virtualization-layer:${LAYERDIR}/dynamic-layers/virt-layer/*/*/*.bb \
     virtualization-layer:${LAYERDIR}/dynamic-layers/virt-layer/*/*/*.bbappend \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,3 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
-LDFLAGS_append_riscv64 = " -pthread"

--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtdeclarative_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtdeclarative_%.bbappend
@@ -1,3 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
-LDFLAGS_append_riscv64 = " -pthread"


### PR DESCRIPTION
meta-qt5 now has the same overides upstream, let's remove them for
meta-riscv.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>