### PR TITLE
musl: Refresh patch on top of latest musl

### DIFF
--- a/recipes-core/musl/musl/0001-Remove-ARMSUBARCH-relic-from-configure.patch
+++ b/recipes-core/musl/musl/0001-Remove-ARMSUBARCH-relic-from-configure.patch
@@ -1,7 +1,7 @@
-From a1139168d22122b014ea8e5102f326426a2c15ba Mon Sep 17 00:00:00 2001
+From 5ed61f2b51eea1bca9b549582f08d55ae40e7425 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 03:17:45 -0400
-Subject: [PATCH 01/15] Remove ARMSUBARCH relic from configure
+Subject: [PATCH 01/16] Remove ARMSUBARCH relic from configure
 
 ---
  configure | 5 -----
@@ -24,5 +24,5 @@ index 9abbbd66..acbfa8f2 100755
  # Some archs (powerpc) have different possible long double formats
  # that the compiler can be configured for. The logic for whether this
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0002-time64-Don-t-make-aliases-to-nonexistent-syscalls.patch
+++ b/recipes-core/musl/musl/0002-time64-Don-t-make-aliases-to-nonexistent-syscalls.patch
@@ -1,7 +1,7 @@
-From 03d068679c7eff4fadc83fada190671f8f62fa19 Mon Sep 17 00:00:00 2001
+From 9fcf025503dfe3478c77cd07a3e29bd2598b42dd Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 03:27:03 -0400
-Subject: [PATCH 02/15] time64: Don't make aliases to nonexistent syscalls
+Subject: [PATCH 02/16] time64: Don't make aliases to nonexistent syscalls
 
 riscv32 and future architectures lack the _time32 variants entirely, so
 don't try to use their numbers.
@@ -68,5 +68,5 @@ index d5f294d4..4f41e1dc 100644
  #endif
  
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0003-time64-Only-getrlimit-setrlimit-if-they-exist.patch
+++ b/recipes-core/musl/musl/0003-time64-Only-getrlimit-setrlimit-if-they-exist.patch
@@ -1,13 +1,13 @@
-From b8b6f6ce49bac68e1e953dafde8421f8e33d656b Mon Sep 17 00:00:00 2001
+From 73f38d909e6a8573b33f7c0e0827a5b14e416533 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 03:31:05 -0400
-Subject: [PATCH 03/15] time64: Only getrlimit/setrlimit if they exist
+Subject: [PATCH 03/16] time64: Only getrlimit/setrlimit if they exist
 
 riscv32 and future architectures only provide prlimit64.
 ---
  src/misc/getrlimit.c | 6 +++++-
- src/misc/setrlimit.c | 6 +++++-
- 2 files changed, 10 insertions(+), 2 deletions(-)
+ src/misc/setrlimit.c | 2 ++
+ 2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/src/misc/getrlimit.c b/src/misc/getrlimit.c
 index 2ab2f0f4..bf676307 100644
@@ -39,33 +39,19 @@ index 2ab2f0f4..bf676307 100644
  
  weak_alias(getrlimit, getrlimit64);
 diff --git a/src/misc/setrlimit.c b/src/misc/setrlimit.c
-index 7a66ab29..62eba5f3 100644
+index 8340aee0..4cf2c607 100644
 --- a/src/misc/setrlimit.c
 +++ b/src/misc/setrlimit.c
-@@ -8,7 +8,6 @@
- 
- static int __setrlimit(int resource, const struct rlimit *rlim)
+@@ -16,7 +16,9 @@ static void do_setrlimit(void *p)
  {
--	unsigned long k_rlim[2];
- 	struct rlimit tmp;
- 	if (SYSCALL_RLIM_INFINITY != RLIM_INFINITY) {
- 		tmp = *rlim;
-@@ -17,10 +16,15 @@ static int __setrlimit(int resource, const struct rlimit *rlim)
- 		rlim = &tmp;
- 	}
- 	int ret = __syscall(SYS_prlimit64, 0, resource, rlim, 0);
+ 	struct ctx *c = p;
+ 	if (c->err>0) return;
 +#ifdef SYS_setrlimit
-+	unsigned long k_rlim[2];
- 	if (ret != -ENOSYS) return ret;
- 	k_rlim[0] = MIN(rlim->rlim_cur, MIN(-1UL, SYSCALL_RLIM_INFINITY));
- 	k_rlim[1] = MIN(rlim->rlim_max, MIN(-1UL, SYSCALL_RLIM_INFINITY));
- 	return __syscall(SYS_setrlimit, resource, k_rlim);
-+#else
-+	return ret;
+ 	c->err = -__syscall(SYS_setrlimit, c->res, c->lim);
 +#endif
  }
  
- struct ctx {
+ int setrlimit(int resource, const struct rlimit *rlim)
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0004-time64-Only-gettimeofday-settimeofday-if-exist.patch
+++ b/recipes-core/musl/musl/0004-time64-Only-gettimeofday-settimeofday-if-exist.patch
@@ -1,7 +1,7 @@
-From bfab18e41795a322f9b05e7f85e909ac8e591baf Mon Sep 17 00:00:00 2001
+From 8519be9a302dae238d137775d13142716af04581 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 03:33:10 -0400
-Subject: [PATCH 04/15] time64: Only gettimeofday/settimeofday if exist
+Subject: [PATCH 04/16] time64: Only gettimeofday/settimeofday if exist
 
 riscv64 and future architectures only provide the clock_ functions.
 ---
@@ -42,5 +42,5 @@ index 3e1d0975..c7e66a51 100644
  #endif
  }
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0005-Add-src-internal-statx.h.patch
+++ b/recipes-core/musl/musl/0005-Add-src-internal-statx.h.patch
@@ -1,7 +1,7 @@
-From 8269f8eb73a17a882260dd60c30429f1eb0a27d8 Mon Sep 17 00:00:00 2001
+From eca94dccba29fb2862884472ae8d30672480f8f4 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 03:45:08 -0400
-Subject: [PATCH 05/15] Add src/internal/statx.h
+Subject: [PATCH 05/16] Add src/internal/statx.h
 
 We need to make internal syscalls to SYS_statx when SYS_fstatat is not
 available without changing the musl API.
@@ -90,5 +90,5 @@ index de165b5c..230a83fc 100644
  
  	*st = (struct stat){
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0006-Only-call-fstatat-if-defined.patch
+++ b/recipes-core/musl/musl/0006-Only-call-fstatat-if-defined.patch
@@ -1,7 +1,7 @@
-From 018b1b207e771304ea6bd6346c87d1f4115a172f Mon Sep 17 00:00:00 2001
+From e7711de591aed7e3a182880c3c8f5b527c0c67e8 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 03:59:59 -0400
-Subject: [PATCH 06/15] Only call fstatat if defined
+Subject: [PATCH 06/16] Only call fstatat if defined
 
 riscv32 and future architectures lack it.
 ---
@@ -205,5 +205,5 @@ index d3cefa82..542c8ce4 100644
  	__syscall(SYS_close, fd);
  	return map == MAP_FAILED ? 0 : map;
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0007-Emulate-wait4-using-waitid.patch
+++ b/recipes-core/musl/musl/0007-Emulate-wait4-using-waitid.patch
@@ -1,7 +1,7 @@
-From 121eae5570d791c8c704905f4df2575654faba0b Mon Sep 17 00:00:00 2001
+From 1a8f65f2b8d33dc09f6ccb6a7bd6ca85760cf720 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:20:45 -0400
-Subject: [PATCH 07/15] Emulate wait4 using waitid
+Subject: [PATCH 07/16] Emulate wait4 using waitid
 
 riscv32 and future architectures lack wait4.
 
@@ -154,10 +154,10 @@ index 080a4262..b60d8f2c 100644
  	return status;
  }
 diff --git a/src/unistd/faccessat.c b/src/unistd/faccessat.c
-index 76bbd4c7..8bf34995 100644
+index 557503eb..8e8689c1 100644
 --- a/src/unistd/faccessat.c
 +++ b/src/unistd/faccessat.c
-@@ -34,7 +34,6 @@ int faccessat(int fd, const char *filename, int amode, int flag)
+@@ -39,7 +39,6 @@ int faccessat(int fd, const char *filename, int amode, int flag)
  	char stack[1024];
  	sigset_t set;
  	pid_t pid;
@@ -165,7 +165,7 @@ index 76bbd4c7..8bf34995 100644
  	int ret, p[2];
  
  	if (pipe2(p, O_CLOEXEC)) return __syscall_ret(-EBUSY);
-@@ -48,7 +47,12 @@ int faccessat(int fd, const char *filename, int amode, int flag)
+@@ -53,7 +52,12 @@ int faccessat(int fd, const char *filename, int amode, int flag)
  	if (pid<0 || __syscall(SYS_read, p[0], &ret, sizeof ret) != sizeof(ret))
  		ret = -EBUSY;
  	__syscall(SYS_close, p[0]);
@@ -179,5 +179,5 @@ index 76bbd4c7..8bf34995 100644
  	__restore_sigs(&set);
  
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0008-riscv-Fall-back-to-syscall-__riscv_flush_icache.patch
+++ b/recipes-core/musl/musl/0008-riscv-Fall-back-to-syscall-__riscv_flush_icache.patch
@@ -1,7 +1,7 @@
-From ce443fcf9332f9bda0eeed4cf50174bae3732417 Mon Sep 17 00:00:00 2001
+From d7bc65df3f6f3026da2094143342e58cd6bdd321 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:23:40 -0400
-Subject: [PATCH 08/15] riscv: Fall back to syscall __riscv_flush_icache
+Subject: [PATCH 08/16] riscv: Fall back to syscall __riscv_flush_icache
 
 Matches glibc behavior and fixes a case where we could fall off the
 function without returning a value.
@@ -22,5 +22,5 @@ index 0eb051c2..9cacac2b 100644
  weak_alias(__riscv_flush_icache, riscv_flush_icache);
  #endif
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0009-riscv32-Target-and-subtarget-detection.patch
+++ b/recipes-core/musl/musl/0009-riscv32-Target-and-subtarget-detection.patch
@@ -1,7 +1,7 @@
-From 0922e3b87460a5601fb957f3c06fcd18db9f71d2 Mon Sep 17 00:00:00 2001
+From 798f6231faa7f684962b6ff72d22aa9e268840ed Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:26:50 -0400
-Subject: [PATCH 09/15] riscv32: Target and subtarget detection
+Subject: [PATCH 09/16] riscv32: Target and subtarget detection
 
 ---
  configure | 3 ++-
@@ -29,5 +29,5 @@ index acbfa8f2..2e217c7e 100755
  trycppif __riscv_float_abi_single "$t" && SUBARCH=${SUBARCH}-sp
  fi
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0010-riscv32-add-arch-headers.patch
+++ b/recipes-core/musl/musl/0010-riscv32-add-arch-headers.patch
@@ -1,7 +1,7 @@
-From 8c8c8ca3517984d04d6463690418716702fe1bdb Mon Sep 17 00:00:00 2001
+From bf15d3589b0bc2bcbe9bf1c49bc993ca77e20951 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:40:29 -0400
-Subject: [PATCH 10/15] riscv32: add arch headers
+Subject: [PATCH 10/16] riscv32: add arch headers
 
 These are mostly copied from riscv64.  _Addr and _Reg had to become int
 to avoid errors in libstdc++ when size_t and std::size_t mismatch.
@@ -845,5 +845,5 @@ index 00000000..9e916c76
 +#define VDSO_CGT_SYM "__vdso_clock_gettime"
 +#define VDSO_CGT_VER "LINUX_2.6" */
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0011-riscv32-Add-fenv-and-math.patch
+++ b/recipes-core/musl/musl/0011-riscv32-Add-fenv-and-math.patch
@@ -1,7 +1,7 @@
-From 12a435f0616337afa55a61b5fbcb8d0c8b2acbea Mon Sep 17 00:00:00 2001
+From 748bf9c7b74ee056d4d4346f49ea6f824d845f08 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:45:44 -0400
-Subject: [PATCH 11/15] riscv32: Add fenv and math
+Subject: [PATCH 11/16] riscv32: Add fenv and math
 
 These are identical to riscv64.
 ---
@@ -359,5 +359,5 @@ index 00000000..610c2cf8
 +
 +#endif
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0012-riscv32-Add-dlsym.patch
+++ b/recipes-core/musl/musl/0012-riscv32-Add-dlsym.patch
@@ -1,7 +1,7 @@
-From 31fe4a4dc4435c7eb2d29902de20a1a78b17a418 Mon Sep 17 00:00:00 2001
+From 0bb97d2cf32b62aa276414c68b90d6fa319cf16c Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:46:33 -0400
-Subject: [PATCH 12/15] riscv32: Add dlsym
+Subject: [PATCH 12/16] riscv32: Add dlsym
 
 Identical to riscv64.
 ---
@@ -22,5 +22,5 @@ index 00000000..2bafd72d
 +	mv a2, ra
 +	tail __dlsym
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0013-riscv32-Add-jmp_buf-and-sigreturn.patch
+++ b/recipes-core/musl/musl/0013-riscv32-Add-jmp_buf-and-sigreturn.patch
@@ -1,7 +1,7 @@
-From 314a0b81fc9bb69ac53f9bc1b367e08c772a2d23 Mon Sep 17 00:00:00 2001
+From 0b4555370e3b615453ce002a375809870fe8d8ed Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:54:44 -0400
-Subject: [PATCH 13/15] riscv32: Add jmp_buf and sigreturn
+Subject: [PATCH 13/16] riscv32: Add jmp_buf and sigreturn
 
 Largely copied from riscv64 but required recalculation of offsets.
 ---
@@ -154,5 +154,5 @@ index 00000000..c1caeab1
 +.hidden __sigsetjmp_tail
 +	tail __sigsetjmp_tail
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0014-riscv32-Add-thread-support.patch
+++ b/recipes-core/musl/musl/0014-riscv32-Add-thread-support.patch
@@ -1,7 +1,7 @@
-From 3a1861e54d4e891229a3ff94d00ba4da7030d81c Mon Sep 17 00:00:00 2001
+From 09cfd9ee37e253d5ec1afc7ff7df652529e766c6 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:56:46 -0400
-Subject: [PATCH 14/15] riscv32: Add thread support
+Subject: [PATCH 14/16] riscv32: Add thread support
 
 Identical to riscv64 except for stack offsets in clone.
 ---
@@ -116,5 +116,5 @@ index 00000000..079d1ba0
 +__cp_cancel:
 +	tail __cancel
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0015-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch
+++ b/recipes-core/musl/musl/0015-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch
@@ -1,7 +1,7 @@
-From b833e050dc341733fbf26a8f8074d90cd1eb587b Mon Sep 17 00:00:00 2001
+From fb2d200423299843818884801e2598dd643ec834 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Wed, 9 Sep 2020 11:57:54 -0700
-Subject: [PATCH 15/15] Change definitions of F_GETLK, F_SETLK, F_SETLKW
+Subject: [PATCH 15/16] Change definitions of F_GETLK, F_SETLK, F_SETLKW
 
 * gdb HEAD wants ELF_NFPREG, so I set it in bits/user.h to the value
   gdb needs.  (glibc does #define ELF_NFPREG NFPREG and expects gdb
@@ -197,5 +197,5 @@ index e5ff27ca..9de4073f 100644
 +	return __syscall_ret(__wait4(pid, status, options, 0, 1));
  }
 -- 
-2.28.0
+2.29.2
 

--- a/recipes-core/musl/musl/0016-riscv32-Wire-new-syscalls.patch
+++ b/recipes-core/musl/musl/0016-riscv32-Wire-new-syscalls.patch
@@ -1,0 +1,33 @@
+From 9fb8b132642520042ab4734ac1f0abce688bbea9 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 30 Oct 2020 12:16:29 -0700
+Subject: [PATCH 16/16] riscv32: Wire new syscalls
+
+- add __NR_faccessat2 from linux v5.8
+- add pidfd_getfd and openat2 syscall numbers from linux v5.6
+- add clone3 syscall number from linux v5.3
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ arch/riscv32/bits/syscall.h.in | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/arch/riscv32/bits/syscall.h.in b/arch/riscv32/bits/syscall.h.in
+index 852d2aaa..4b145fa3 100644
+--- a/arch/riscv32/bits/syscall.h.in
++++ b/arch/riscv32/bits/syscall.h.in
+@@ -279,7 +279,10 @@
+ #define __NR_fsmount		432
+ #define __NR_fspick		433
+ #define __NR_pidfd_open		434
+-
++#define __NR_clone3		435
++#define __NR_openat2		437
++#define __NR_pidfd_getfd	438
++#define __NR_faccessat2		439
+ #define __NR_futex __NR_futex_time64
+ 
+ #define __NR_sysriscv __NR_arch_specific_syscall
+-- 
+2.29.2
+

--- a/recipes-core/musl/musl_%.bbappend
+++ b/recipes-core/musl/musl_%.bbappend
@@ -16,4 +16,5 @@ SRC_URI_append_riscv32 = "\
     file://0013-riscv32-Add-jmp_buf-and-sigreturn.patch \
     file://0014-riscv32-Add-thread-support.patch \
     file://0015-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch \
+    file://0016-riscv32-Wire-new-syscalls.patch \
 "


### PR DESCRIPTION
Wire new syscalls upto 5.8 kernel for rv32

Signed-off-by: Khem Raj <raj.khem@gmail.com>


