### PR TITLE
python3-matplotlib,smem: Enable builds for rv32

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -74,9 +74,6 @@ INSANE_SKIP_append_pn-perf_riscv32 = " textrel"
 COMPATIBLE_HOST_pn-openh264_riscv32 = "null"
 # Need to port - tcf/cpudefs-mdep.h
 COMPATIBLE_HOST_pn-tcf-agent_riscv32 = "null"
-# ld.lld: error: lto.tmp: cannot link object files with different floating-point ABI
-COMPATIBLE_HOST_pn-python3-matplotlib_riscv32 = "null"
-COMPATIBLE_HOST_pn-smem_riscv32 = "null"
 # needs SYS_ppoll and SYS_pselect6
 COMPATIBLE_HOST_pn-lttng-tools_riscv32 = "null"
 # LTTng-modules requires CONFIG_KPROBES on kernels >= 5.7.0


### PR DESCRIPTION
python3-matplotlib is now fixed to build for rv32 on meta-python

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

