### PR TITLE
glibc: Remove glibc bbappend

### DIFF
--- a/recipes-core/glibc/glibc_2.32.bbappend
+++ b/recipes-core/glibc/glibc_2.32.bbappend
@@ -1,2 +1,0 @@
-SRCBRANCH_qemuriscv32 = "master"
-SRCREV_glibc_qemuriscv32 = "567b1705017a0876b1cf9661a20521ef1e4ddc54"


### PR DESCRIPTION
glibc 2.33 is now in OE-Core and supports RV32, so let's remove the 2.32
bbappend.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>