### PR TITLE
glibc: Drop bbappend for 2.32

### DIFF
--- a/recipes-core/glibc/glibc_2.32.bbappend
+++ b/recipes-core/glibc/glibc_2.32.bbappend
@@ -1,2 +1,0 @@
-SRCBRANCH_qemuriscv32 = "master"
-SRCREV_glibc_qemuriscv32 = "567b1705017a0876b1cf9661a20521ef1e4ddc54"


### PR DESCRIPTION
OE-core has upgraded to 2.33 now in master which has rv32 port already
in it.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

