### PR TITLE
musl: Update the rv32 patches to apply on latest musl

### DIFF
--- a/recipes-core/busybox/busybox/0001-hwclock-Check-for-SYS_settimeofday-before-calling-sy.patch
+++ b/recipes-core/busybox/busybox/0001-hwclock-Check-for-SYS_settimeofday-before-calling-sy.patch
@@ -1,0 +1,45 @@
+From 7f3b60ca20780418960629bdcbe2898f065ed3d7 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 7 Mar 2021 17:30:24 -0800
+Subject: [PATCH] hwclock: Check for SYS_settimeofday before calling syscall
+
+Some newer architectures e.g. RISCV32 have 64bit time_t from get go and
+thusly do not have gettimeofday_time64/settimeofday_time64 implemented
+therefore check for SYS_settimeofday definition before making the
+syscall. Fixes build for riscv32 and it will bail out at runtime.
+
+Upstream-Status: Submitted [http://lists.busybox.net/pipermail/busybox/2021-March/088583.html]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ util-linux/hwclock.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/util-linux/hwclock.c b/util-linux/hwclock.c
+index 723b09589..b9faaabbc 100644
+--- a/util-linux/hwclock.c
++++ b/util-linux/hwclock.c
+@@ -131,6 +131,7 @@ static void show_clock(const char **pp_rtcname, int utc)
+ 
+ static void set_kernel_tz(const struct timezone *tz)
+ {
++	int ret = 1;
+ #if LIBC_IS_MUSL
+ 	/* musl libc does not pass tz argument to syscall
+ 	 * because "it's deprecated by POSIX, therefore it's fine
+@@ -139,9 +140,11 @@ static void set_kernel_tz(const struct timezone *tz)
+ #if !defined(SYS_settimeofday) && defined(SYS_settimeofday_time32)
+ # define SYS_settimeofday SYS_settimeofday_time32
+ #endif
+-	int ret = syscall(SYS_settimeofday, NULL, tz);
++#if defined(SYS_settimeofday)
++	ret = syscall(SYS_settimeofday, NULL, tz);
++#endif
+ #else
+-	int ret = settimeofday(NULL, tz);
++	ret = settimeofday(NULL, tz);
+ #endif
+ 	if (ret)
+ 		bb_simple_perror_msg_and_die("settimeofday");
+-- 
+2.30.1
+

--- a/recipes-core/busybox/busybox_1.33%.bbappend
+++ b/recipes-core/busybox/busybox_1.33%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_riscv32 = " file://0001-hwclock-Check-for-SYS_settimeofday-before-calling-sy.patch"

--- a/recipes-core/musl/musl/0015-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch
+++ b/recipes-core/musl/musl/0015-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch
@@ -38,8 +38,6 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  create mode 100644 arch/riscv32/bits/sem.h
  create mode 100644 arch/riscv32/bits/shm.h
 
-diff --git a/arch/riscv32/bits/fcntl.h b/arch/riscv32/bits/fcntl.h
-index ecb4d18f..66f84fac 100644
 --- a/arch/riscv32/bits/fcntl.h
 +++ b/arch/riscv32/bits/fcntl.h
 @@ -24,14 +24,15 @@
@@ -61,16 +59,10 @@ index ecb4d18f..66f84fac 100644
  #define F_SETOWN_EX 15
  #define F_GETOWN_EX 16
  
-diff --git a/arch/riscv32/bits/ipcstat.h b/arch/riscv32/bits/ipcstat.h
-new file mode 100644
-index 00000000..4f4fcb0c
 --- /dev/null
 +++ b/arch/riscv32/bits/ipcstat.h
 @@ -0,0 +1 @@
 +#define IPC_STAT 0x102
-diff --git a/arch/riscv32/bits/msg.h b/arch/riscv32/bits/msg.h
-new file mode 100644
-index 00000000..7bbbb2bf
 --- /dev/null
 +++ b/arch/riscv32/bits/msg.h
 @@ -0,0 +1,18 @@
@@ -92,9 +84,6 @@ index 00000000..7bbbb2bf
 +	time_t msg_rtime;
 +	time_t msg_ctime;
 +};
-diff --git a/arch/riscv32/bits/sem.h b/arch/riscv32/bits/sem.h
-new file mode 100644
-index 00000000..544e3d2a
 --- /dev/null
 +++ b/arch/riscv32/bits/sem.h
 @@ -0,0 +1,18 @@
@@ -116,9 +105,6 @@ index 00000000..544e3d2a
 +	time_t sem_otime;
 +	time_t sem_ctime;
 +};
-diff --git a/arch/riscv32/bits/shm.h b/arch/riscv32/bits/shm.h
-new file mode 100644
-index 00000000..725fb469
 --- /dev/null
 +++ b/arch/riscv32/bits/shm.h
 @@ -0,0 +1,31 @@
@@ -153,8 +139,6 @@ index 00000000..725fb469
 +	unsigned long shm_tot, shm_rss, shm_swp;
 +	unsigned long __swap_attempts, __swap_successes;
 +};
-diff --git a/arch/riscv32/bits/user.h b/arch/riscv32/bits/user.h
-index 2da743ea..0d37de0b 100644
 --- a/arch/riscv32/bits/user.h
 +++ b/arch/riscv32/bits/user.h
 @@ -1,5 +1,6 @@
@@ -164,29 +148,14 @@ index 2da743ea..0d37de0b 100644
 +#define ELF_NFPREG 33
  typedef unsigned long elf_greg_t, elf_gregset_t[ELF_NGREG];
  typedef union __riscv_mc_fp_state elf_fpregset_t;
-diff --git a/arch/riscv32/syscall_arch.h b/arch/riscv32/syscall_arch.h
-index 9e916c76..c507f15f 100644
 --- a/arch/riscv32/syscall_arch.h
 +++ b/arch/riscv32/syscall_arch.h
-@@ -76,3 +76,5 @@ static inline long __syscall6(long n, long a, long b, long c, long d, long e, lo
+@@ -76,3 +76,5 @@ static inline long __syscall6(long n, lo
  /* We don't have a clock_gettime function.
  #define VDSO_CGT_SYM "__vdso_clock_gettime"
  #define VDSO_CGT_VER "LINUX_2.6" */
 +
 +#define IPC_64 0
-diff --git a/arch/riscv64/bits/user.h b/arch/riscv64/bits/user.h
-index 2da743ea..0d37de0b 100644
---- a/arch/riscv64/bits/user.h
-+++ b/arch/riscv64/bits/user.h
-@@ -1,5 +1,6 @@
- #include <signal.h>
- 
- #define ELF_NGREG 32
-+#define ELF_NFPREG 33
- typedef unsigned long elf_greg_t, elf_gregset_t[ELF_NGREG];
- typedef union __riscv_mc_fp_state elf_fpregset_t;
-diff --git a/src/process/waitpid.c b/src/process/waitpid.c
-index e5ff27ca..9de4073f 100644
 --- a/src/process/waitpid.c
 +++ b/src/process/waitpid.c
 @@ -3,5 +3,5 @@
@@ -196,6 +165,3 @@ index e5ff27ca..9de4073f 100644
 -	return __wait4(pid, status, options, 0, 1);
 +	return __syscall_ret(__wait4(pid, status, options, 0, 1));
  }
--- 
-2.29.2
-


### PR DESCRIPTION
port on top of oe-core version

Signed-off-by: Khem Raj <raj.khem@gmail.com>

