### PR TITLE
linux-starfive: Use  starfive_vic7100_evb_sd_net_fedora_defconfig

### DIFF
--- a/beaglev.yml
+++ b/beaglev.yml
@@ -35,7 +35,6 @@ local_conf_header:
     CONF_VERSION = "1"
     PACKAGE_CLASSES = "package_rpm"
     SDKMACHINE = "x86_64"
-    TCLIBC = "musl"
   diskmon: |
     BB_DISKMON_DIRS = "\
         STOPTASKS,${TMPDIR},1G,100K \

--- a/recipes-kernel/linux/linux-starfive/0001-drivers-net-wireless-broadcom-fix-out-of-tree-build.patch
+++ b/recipes-kernel/linux/linux-starfive/0001-drivers-net-wireless-broadcom-fix-out-of-tree-build.patch
@@ -1,0 +1,31 @@
+From 274114f3d87869751afa88fc5c820acbb09bbccf Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Date: Mon, 3 May 2021 12:19:30 +0200
+Subject: [PATCH] drivers/net/wireless/broadcom: fix out of tree build
+
+Building out of tree fails due to incorrect include paths.
+
+Upstream-Status: Submitted [https://github.com/starfive-tech/linux/pull/5]
+
+Fixes: 607862a03f15 ("drivers/net/wireless/broadcom: Add WiFi/BT driver BCMDHD")
+Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+---
+ drivers/net/wireless/broadcom/bcmdhd/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/broadcom/bcmdhd/Makefile b/drivers/net/wireless/broadcom/bcmdhd/Makefile
+index e98908ee79ae..1f0065927ac9 100644
+--- a/drivers/net/wireless/broadcom/bcmdhd/Makefile
++++ b/drivers/net/wireless/broadcom/bcmdhd/Makefile
+@@ -26,7 +26,7 @@ DHDCFLAGS = -Wall -Wstrict-prototypes -Dlinux -DBCMDRIVER                 \
+ 	-DPOWERUP_MAX_RETRY=0 -DIFACE_HANG_FORCE_DEV_CLOSE -DWAIT_DEQUEUE     \
+ 	-DWL_EXT_IAPSTA -DWL_ESCAN -DCCODE_LIST                               \
+ 	-DENABLE_INSMOD_NO_FW_LOAD                                            \
+-	-Idrivers/net/wireless/broadcom/bcmdhd -Idrivers/net/wireless/broadcom/bcmdhd/include
++	-I$(srctree)/drivers/net/wireless/broadcom/bcmdhd -I$(srctree)/drivers/net/wireless/broadcom/bcmdhd/include
+ 
+ DHDOFILES = aiutils.o siutils.o sbutils.o bcmutils.o bcmwifi_channels.o   \
+ 	dhd_linux.o dhd_linux_platdev.o dhd_linux_sched.o dhd_pno.o           \
+-- 
+2.31.1
+

--- a/recipes-kernel/linux/linux-starfive_5.10.bb
+++ b/recipes-kernel/linux/linux-starfive_5.10.bb
@@ -4,6 +4,7 @@ inherit kernel
 require recipes-kernel/linux/linux-yocto.inc
 
 SRC_URI = "git://github.com/starfive-tech/linux.git;protocol=git;branch=Fedora \
+           file://0001-drivers-net-wireless-broadcom-fix-out-of-tree-build.patch \
            file://extra.cfg \
           "
 
@@ -20,6 +21,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 KCONFIG_MODE = "--alldefconfig"
-KBUILD_DEFCONFIG_beaglev-starlight-jh7100 = "starfive_vic7100_evb_sd_net_defconfig"
+KBUILD_DEFCONFIG_beaglev-starlight-jh7100 = "starfive_vic7100_evb_sd_net_fedora_defconfig"
 
 COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100)"


### PR DESCRIPTION
This helps fix the time issues we were seeing with current config
which was resulting in bad time being reported from kernel and glibc
strftime() tripping over it.

This fixes all those issues and we can boot glibc based rootfs without
issues

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

