### PR TITLE
opensbi_starfive: Switch to StarFive_VIC_7100 branch name

### DIFF
--- a/recipes-bsp/opensbi/opensbi_starfive-0.8.0.bb
+++ b/recipes-bsp/opensbi/opensbi_starfive-0.8.0.bb
@@ -9,7 +9,7 @@ require recipes-bsp/opensbi/opensbi-payloads.inc
 inherit autotools-brokensep deploy
 
 SRCREV = "2524b0ecd8684b42bc7a4c69794f40f11cbbe2a5"
-SRC_URI = "git://github.com/starfive-tech/opensbi.git;branch=Fedora \
+SRC_URI = "git://github.com/starfive-tech/opensbi.git;branch=StarFive_VIC_7100 \
           "
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
@@ -3,11 +3,11 @@ require recipes-bsp/u-boot/u-boot.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=git;branch=Fedora \
+SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=git;branch=Fedora_VIC_7100_2021.04 \
 	       file://tftp-mmc-boot.txt \
           "
 
-SRCREV = "3f3ac01a29ad1cd5fa519d86f81daead2447f1d4"
+SRCREV = "7b70e1d44ba9702a519ca936cabf19070309123a"
 
 DEPENDS_append = " u-boot-tools-native"
 


### PR DESCRIPTION
Fedora branch seems to have disappeared ( perhaps renamed to
StarFive_VIC_7100) but StarFive_VIC_7100 is now default branch on github
so lets switch to that

Signed-off-by: Khem Raj <raj.khem@gmail.com>

