### PR TITLE
linux-starfive-dev: Use renamed defconfig for beaglev

### DIFF
--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -17,6 +17,6 @@ SRC_URI = "git://github.com/${FORK}/linux.git;protocol=git;branch=${BRANCH} \
 LINUX_VERSION ?= "5.13.0"
 LINUX_VERSION_EXTENSION_append = "-starlight"
 
-KBUILD_DEFCONFIG_beaglev-starlight-jh7100 = "starlight_defconfig"
+KBUILD_DEFCONFIG_beaglev-starlight-jh7100 = "beaglev_defconfig"
 
 COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100)"


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>

