### PR TITLE
lttng-tools: Skip textrel on rv64

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -49,6 +49,7 @@ INSANE_SKIP:append:pn-util-linux:riscv64 = " textrel"
 INSANE_SKIP:append:pn-cmocka:riscv64 = " textrel"
 INSANE_SKIP:append:pn-rust-hello-world:riscv64 = " textrel"
 INSANE_SKIP:append:pn-fish:riscv64 = " textrel"
+INSANE_SKIP:append:pn-lttng-tools:riscv64 = " textrel"
 
 INSANE_SKIP:append:pn-xfsdump:riscv32 = " textrel"
 INSANE_SKIP:append:pn-zabbix:riscv32 = " textrel"


### PR DESCRIPTION
Latest version is causing QA errors e.g.

ERROR: lttng-tools-2.13.0-r0 do_package_qa: QA Issue: lttng-tools: ELF binary /usr/lib/lttng/libexec/lttng-consumerd has relocations in .text
lttng-tools: ELF binary /usr/bin/lttng has relocations in .text
lttng-tools: ELF binary /usr/bin/lttng-crash has relocations in .text
lttng-tools: ELF binary /usr/bin/lttng-relayd has relocations in .text
lttng-tools: ELF binary /usr/bin/lttng-sessiond has relocations in .text [textrel]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

