### PR TITLE
gn: Ignore textrel build QA errors

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -50,6 +50,7 @@ INSANE_SKIP:append:pn-cmocka:riscv64 = " textrel"
 INSANE_SKIP:append:pn-rust-hello-world:riscv64 = " textrel"
 INSANE_SKIP:append:pn-fish:riscv64 = " textrel"
 INSANE_SKIP:append:pn-lttng-tools:riscv64 = " textrel"
+INSANE_SKIP:append:pn-gn:riscv64 = " textrel"
 
 INSANE_SKIP:append:pn-xfsdump:riscv32 = " textrel"
 INSANE_SKIP:append:pn-zabbix:riscv32 = " textrel"


### PR DESCRIPTION
Fixes
ERROR: QA Issue: gn: ELF binary /usr/bin/gn has relocations in .text [textrel]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

