### PR TITLE
libseccomp: Use fork for libseccomp on rv32

### DIFF
--- a/recipes-support/libseccomp/libseccomp_%.bbappend
+++ b/recipes-support/libseccomp/libseccomp_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# RV32 port is still not upstream yet
+
+SRC_URI:riscv32 = "\
+    git://github.com/kraj/libseccomp.git;branch=riscv32;protocol=https \
+    file://run-ptest \
+"
+
+SRCREV:riscv32 = "063724705f6715f9339fd8cbe2eb751f28b3b70d"


### PR DESCRIPTION
libseccomp support is not yet upstreamed.

see https://github.com/seccomp/libseccomp/pull/327

Signed-off-by: Khem Raj <raj.khem@gmail.com>

