### PR TITLE
libseccomp: Substitute valid release number

### DIFF
--- a/recipes-support/libseccomp/libseccomp_%.bbappend
+++ b/recipes-support/libseccomp/libseccomp_%.bbappend
@@ -8,3 +8,7 @@ SRC_URI:riscv32 = "\
 "
 
 SRCREV:riscv32 = "063724705f6715f9339fd8cbe2eb751f28b3b70d"
+
+do_configure:prepend:riscv32() {
+    sed -i -e "s|\[0.0.0\]|\['${PV}'\]|g" ${S}/configure.ac
+}


### PR DESCRIPTION
This helps to ensure that a valid version is encoded for libseccomp
consumers, We dont need it generally since the release comes from a
release branch but rv32 port is on a staging branch of main where
release number is not coded yet and set to 0.0.0

Signed-off-by: Khem Raj <raj.khem@gmail.com>

