### PR TITLE
jemalloc: Ignore textrels on rv32 as well

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -80,6 +80,7 @@ INSANE_SKIP:append:pn-cmocka:riscv32 = " textrel"
 # Only seen when build with gcc
 INSANE_SKIP:append:pn-util-linux:riscv32 = " textrel"
 INSANE_SKIP:append:pn-apitrace:riscv32 = " textrel"
+INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv32 = " textrel"
 
 # These recipe dont _yet_ build for rv32
 COMPATIBLE_HOST:pn-openh264:riscv32 = "null"


### PR DESCRIPTION
ptests end up with textrels

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

