### PR TITLE
conf: Drop using image-prelink

### DIFF
--- a/conf/machine/baremetal-riscv32.conf
+++ b/conf/machine/baremetal-riscv32.conf
@@ -16,7 +16,4 @@ QB_NETWORK_DEVICE = "-device virtio-net-device,netdev=net0,mac=@MAC@"
 QB_ROOTFS_OPT = "-drive file=@ROOTFS@,format=raw,id=hd0 -device virtio-blk-device,drive=hd0"
 QB_SLIRP_OPT = "-netdev user,id=net0,hostfwd=tcp::22222-:22"
 
-# Prelink does not yet work
-USER_CLASSES:remove = "image-prelink"
-
 TCLIBC = "baremetal"

--- a/conf/machine/baremetal-riscv32nf.conf
+++ b/conf/machine/baremetal-riscv32nf.conf
@@ -16,7 +16,4 @@ QB_NETWORK_DEVICE = "-device virtio-net-device,netdev=net0,mac=@MAC@"
 QB_ROOTFS_OPT = "-drive file=@ROOTFS@,format=raw,id=hd0 -device virtio-blk-device,drive=hd0"
 QB_SLIRP_OPT = "-netdev user,id=net0,hostfwd=tcp::22222-:22"
 
-# Prelink does not yet work
-USER_CLASSES:remove = "image-prelink"
-
 TCLIBC = "baremetal"

--- a/conf/machine/baremetal-riscv64.conf
+++ b/conf/machine/baremetal-riscv64.conf
@@ -16,7 +16,4 @@ QB_NETWORK_DEVICE = "-device virtio-net-device,netdev=net0,mac=@MAC@"
 QB_ROOTFS_OPT = "-drive file=@ROOTFS@,format=raw,id=hd0 -device virtio-blk-device,drive=hd0"
 QB_SLIRP_OPT = "-netdev user,id=net0,hostfwd=tcp::22222-:22"
 
-# Prelink does not yet work
-USER_CLASSES:remove = "image-prelink"
-
 TCLIBC = "baremetal"

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ EXTRA_IMAGE_FEATURES:append = " ssh-server-dropbear"
 EXTRA_IMAGE_FEATURES:append = " package-management"
 PACKAGECONFIG:append:pn-qemu-native = " sdl"
 PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
-USER_CLASSES ?= "buildstats buildhistory buildstats-summary image-prelink"
+USER_CLASSES ?= "buildstats buildhistory buildstats-summary"
 
 require conf/distro/include/no-static-libs.inc
 require conf/distro/include/yocto-uninative.inc


### PR DESCRIPTION
image-prelink has been removed in latest yocto ( kirkstone + )
Fixes Issue #325

Signed-off-by: Khem Raj <raj.khem@gmail.com>

