### PR TITLE
Support of the Nezha Allwinner D1 - Yocto kirkstone

### DIFF
--- a/conf/machine/nezha-allwinner-d1.conf
+++ b/conf/machine/nezha-allwinner-d1.conf
@@ -1,0 +1,70 @@
+#@TYPE: Machine
+#@NAME: nezha-allwinner-d1
+#@SOC: Allwinner D1
+#@DESCRIPTION: Machine configuration for Nezha board
+
+require conf/machine/include/riscv/tune-riscv.inc
+
+MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
+
+KERNEL_CLASSES = "kernel-fitimage"
+KERNEL_IMAGETYPE = "fitImage"
+UBOOT_ENV ?= "boot"
+UBOOT_ENV_SUFFIX = "scr.uimg"
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-nezha-dev"
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-nezha"
+
+PREFERRED_VERSION_openocd-native = "riscv"
+PREFERRED_VERSION_openocd = "riscv"
+
+EXTRA_IMAGEDEPENDS += "opensbi"
+RISCV_SBI_PLAT = "generic"
+
+## This sets u-boot as the default OpenSBI payload
+### Nezha board uses TOC1 images loaded by SPL and containing U-Boot, DTB, and
+### OpenSBI so 'RISCV_SBI_PAYLOAD' isn't used.
+### 'RISCV_SBI_FDT' isn't used because the DTB is loaded from RAM at
+### ${fdtcontroladdr}
+#RISCV_SBI_PAYLOAD ?= "u-boot.bin"
+#RISCV_SBI_FDT ?= "sun20i-d1-nezha.dtb"
+
+SERIAL_CONSOLES = "115200;ttyS0"
+
+MACHINE_EXTRA_RRECOMMENDS += " kernel-modules"
+
+IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
+
+### 'KERNEL_DEVICETREE' isn't used because the DTB is loaded from RAM
+### at address ${fdtcontroladdr}
+#KERNEL_DEVICETREE ?= "allwinner/sun20i-d1-nezha.dtb"
+
+## Do not update fstab file when using wic images
+WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+
+EXTRA_IMAGEDEPENDS += "u-boot-nezha"
+UBOOT_MACHINE = "nezha_defconfig"
+
+
+UBOOT_ENTRYPOINT = "0x40200000"
+UBOOT_DTB_LOADADDRESS = "0x4FA00000"
+UBOOT_DTB = "1"
+UBOOT_DTB_BINARY ?= "sun20i-d1-nezha.dtb"
+
+# Deploy boot0 which is used as SPL
+EXTRA_IMAGEDEPENDS += "boot0"
+
+## wic default support
+WKS_FILE_DEPENDS ?= " \
+    u-boot-nezha \
+    opensbi \
+    e2fsprogs-native \
+    bmap-tools-native \
+"
+
+IMAGE_BOOT_FILES ?= " \
+    ${KERNEL_IMAGETYPE} \
+    boot.scr.uimg \
+    uEnv.txt \
+"
+
+WKS_FILE ?= "nezha.wks"

--- a/nezha.yml
+++ b/nezha.yml
@@ -1,0 +1,56 @@
+header:
+  version: 8
+
+distro: poky
+
+machine: nezha-allwinner-d1
+
+target:
+  - core-image-minimal
+
+repos:
+  meta-riscv:
+
+  poky:
+    url: https://git.yoctoproject.org/git/poky
+    refspec: master
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: https://git.openembedded.org/meta-openembedded
+    refspec: master
+    layers:
+      meta-oe:
+      meta-networking:
+      meta-python:
+
+bblayers_conf_header:
+  standard: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+    BBPATH = "${TOPDIR}"
+    BBFILES ?= ""
+local_conf_header:
+  standard: |
+    CONF_VERSION = "2"
+    PACKAGE_CLASSES = "package_rpm"
+    SDKMACHINE = "x86_64"
+    # Use 'haveged' instead 'rng-tools' due to 'SIGSEGV' error during start 'rngd'
+    PACKAGE_EXCLUDE:append = "rng-tools"
+    IMAGE_INSTALL:append = "haveged"
+    IMAGE_FEATURES += " \
+        ssh-server-openssh \
+        debug-tweaks \
+    "
+  diskmon: |
+    BB_DISKMON_DIRS = "\
+        STOPTASKS,${TMPDIR},1G,100K \
+        STOPTASKS,${DL_DIR},1G,100K \
+        STOPTASKS,${SSTATE_DIR},1G,100K \
+        STOPTASKS,/tmp,100M,100K \
+        HALT,${TMPDIR},100M,1K \
+        HALT,${DL_DIR},100M,1K \
+        HALT,${SSTATE_DIR},100M,1K \
+        HALT,/tmp,10M,1K"

--- a/recipes-bsp/boot0/boot0.bb
+++ b/recipes-bsp/boot0/boot0.bb
@@ -1,0 +1,31 @@
+DESCRIPTION = "Mainline friendly Secondary Program Loader for Allwinner D1"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = " \
+	git://github.com/smaeul/sun20i_d1_spl;protocol=https;branch=mainline \
+	file://0001-config.mk-Allow-overriding-CC-and-other-tools.patch \
+	file://0002-config.mk-Remove-nostdinc.patch \
+	file://0003-riscv-fix-build-with-binutils-2.38.patch \
+"
+
+PV = "1.0+git${SRCPV}"
+SRCREV = "0ad88bfdb723b1ac74cca96122918f885a4781ac"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = "p=sun20iw1p1 mmc"
+
+inherit deploy
+
+do_compile () {
+	unset LDFLAGS
+	oe_runmake
+}
+
+do_deploy() {
+    install -m 644 ${S}/nboot/boot0_sdcard_sun20iw1p1.bin ${DEPLOYDIR}
+}
+
+addtask deploy before do_build after do_compile

--- a/recipes-bsp/boot0/files/0001-config.mk-Allow-overriding-CC-and-other-tools.patch
+++ b/recipes-bsp/boot0/files/0001-config.mk-Allow-overriding-CC-and-other-tools.patch
@@ -1,0 +1,49 @@
+From cef8a54a2199385b424a6d3a17d081dd4bf3c8ba Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Tue, 29 Mar 2022 21:54:10 +0200
+Subject: [PATCH 1/4] config.mk: Allow overriding CC and other tools
+
+It helps build systems defaults to be used e.g. OE's default CC has
+additional bits which are needed for regular functioning of the cross
+compiler.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+---
+ mk/config.mk | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/mk/config.mk b/mk/config.mk
+index 98abfd1fe2f5..3b8a1b1de9c6 100644
+--- a/mk/config.mk
++++ b/mk/config.mk
+@@ -6,16 +6,16 @@ ifneq ($(SKIP_AUTO_CONF),yes)
+ sinclude $(TOPDIR)/autoconf.mk
+ endif
+ 
+-AS		= $(CROSS_COMPILE)as
+-LD		= $(CROSS_COMPILE)ld
+-CC		= $(CROSS_COMPILE)gcc
+-CPP		= $(CC) -E
+-AR		= $(CROSS_COMPILE)ar
+-NM		= $(CROSS_COMPILE)nm
+-LDR		= $(CROSS_COMPILE)ldr
+-STRIP		= $(CROSS_COMPILE)strip
+-OBJCOPY		= $(CROSS_COMPILE)objcopy
+-OBJDUMP		= $(CROSS_COMPILE)objdump
++AS		?= $(CROSS_COMPILE)as
++LD		?= $(CROSS_COMPILE)ld
++CC		?= $(CROSS_COMPILE)gcc
++CPP		?= $(CC) -E
++AR		?= $(CROSS_COMPILE)ar
++NM		?= $(CROSS_COMPILE)nm
++LDR		?= $(CROSS_COMPILE)ldr
++STRIP		?= $(CROSS_COMPILE)strip
++OBJCOPY		?= $(CROSS_COMPILE)objcopy
++OBJDUMP		?= $(CROSS_COMPILE)objdump
+ 
+ ##########################################################
+ ifeq (x$(CPU), xriscv64)
+-- 
+2.25.1
+

--- a/recipes-bsp/boot0/files/0002-config.mk-Remove-nostdinc.patch
+++ b/recipes-bsp/boot0/files/0002-config.mk-Remove-nostdinc.patch
@@ -1,0 +1,31 @@
+From b25fe9956031b5e5ff901d7853e05fe35f1b8b5b Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Tue, 29 Mar 2022 21:56:00 +0200
+Subject: [PATCH 2/4] config.mk: Remove -nostdinc
+
+This helps building on different kind of toolchains e.g. OE/Yocto where
+the standard install paths may vary and this is better to avoid to have
+to poke into system to find headers etc.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+---
+ mk/config.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mk/config.mk b/mk/config.mk
+index 3b8a1b1de9c6..75098cf32ea6 100644
+--- a/mk/config.mk
++++ b/mk/config.mk
+@@ -30,7 +30,7 @@ SPLINCLUDE    := \
+ 		-I$(SRCTREE)/include/arch/$(PLATFORM)/ \
+ 		-I$(SRCTREE)/include/openssl/
+ 
+- COMM_FLAGS := -nostdinc  $(COMPILEINC) \
++ COMM_FLAGS := $(COMPILEINC) \
+ 	-g  -Os   -fno-common \
+ 	-ffunction-sections \
+ 	-fno-builtin -ffreestanding \
+-- 
+2.25.1
+

--- a/recipes-bsp/boot0/files/0003-riscv-fix-build-with-binutils-2.38.patch
+++ b/recipes-bsp/boot0/files/0003-riscv-fix-build-with-binutils-2.38.patch
@@ -1,0 +1,51 @@
+From 7ab3906f6b986923bb0d94434284163014861d70 Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Tue, 29 Mar 2022 21:57:54 +0200
+Subject: [PATCH 4/4] riscv: fix build with binutils 2.38
+
+From version 2.38, binutils default to ISA spec version 20191213. This
+means that the csr read/write (csrr*/csrw*) instructions and fence.i
+instruction has separated from the `I` extension, become two standalone
+extensions: Zicsr and Zifencei.
+
+The fix is to specify those extensions explicitely in -march. However as
+older binutils version do not support this, we first need to detect
+that.
+
+Fixes:
+	mmu.c: Assembler messages:
+	mmu.c:85: Error: unrecognized opcode `fence.i'
+
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+---
+ mk/config.mk | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/mk/config.mk b/mk/config.mk
+index 72ecbf58abab..4bd54b254814 100644
+--- a/mk/config.mk
++++ b/mk/config.mk
+@@ -85,10 +85,18 @@ SPLINCLUDE    := \
+  COMM_FLAGS += -mno-unaligned-access
+ endif
+ 
++# Newer binutils versions default to ISA spec version 20191213 which moves some
++# instructions from the I extension to the Zicsr and Zifencei extensions.
++toolchain-need-zicsr-zifencei := $(call cc-option-yn, -march=$(MARCH)_zicsr_zifencei)
++zicsr_zifencei-$(toolchain-need-zicsr-zifencei) := _zicsr_zifencei
++RISCV_MARCH := $(MARCH)_zicsr_zifencei
++
++ARCH_FLAGS = -march=$(RISCV_MARCH) -mabi=$(MABI)
++
+ SPLINCLUDE += -I$(SRCTREE)/libfdt
+ 
+-C_FLAGS += $(SPLINCLUDE)   $(COMM_FLAGS)
+-S_FLAGS += $(SPLINCLUDE)   -D__ASSEMBLY__  $(COMM_FLAGS)
++C_FLAGS += $(SPLINCLUDE)   $(COMM_FLAGS) $(ARCH_FLAGS)
++S_FLAGS += $(SPLINCLUDE)   -D__ASSEMBLY__  $(COMM_FLAGS) $(ARCH_FLAGS)
+ LDFLAGS_GC += --gc-sections
+ #LDFLAGS += --gap-fill=0xff
+ export LDFLAGS_GC
+-- 
+2.25.1
+

--- a/recipes-bsp/opensbi/files/0001-lib-utils-fdt-Require-match-data-to-be-const.patch
+++ b/recipes-bsp/opensbi/files/0001-lib-utils-fdt-Require-match-data-to-be-const.patch
@@ -1,0 +1,66 @@
+From 65410b015fc16d1c47b1972f89a35f5c8dd10abe Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Tue, 19 Oct 2021 19:25:37 -0500
+Subject: [PATCH 1/2] lib: utils/fdt: Require match data to be const
+
+Match data stores hardware attributes which do not change at runtime, so
+it does not need to be mutable. Make it const.
+
+Signed-off-by: Samuel Holland <samuel@sholland.org>
+---
+ include/sbi_utils/fdt/fdt_helper.h | 2 +-
+ lib/utils/ipi/fdt_ipi_mswi.c       | 2 +-
+ lib/utils/reset/fdt_reset_gpio.c   | 4 ++--
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/include/sbi_utils/fdt/fdt_helper.h b/include/sbi_utils/fdt/fdt_helper.h
+index 24fee7a339c3..fde00b72fc1d 100644
+--- a/include/sbi_utils/fdt/fdt_helper.h
++++ b/include/sbi_utils/fdt/fdt_helper.h
+@@ -15,7 +15,7 @@
+ 
+ struct fdt_match {
+ 	const char *compatible;
+-	void *data;
++	const void *data;
+ };
+ 
+ #define FDT_MAX_PHANDLE_ARGS 16
+diff --git a/lib/utils/ipi/fdt_ipi_mswi.c b/lib/utils/ipi/fdt_ipi_mswi.c
+index 1f0fda71c087..0176941a7d68 100644
+--- a/lib/utils/ipi/fdt_ipi_mswi.c
++++ b/lib/utils/ipi/fdt_ipi_mswi.c
+@@ -51,7 +51,7 @@ static int ipi_mswi_cold_init(void *fdt, int nodeoff,
+ 	return 0;
+ }
+ 
+-static unsigned long clint_offset = CLINT_MSWI_OFFSET;
++static const unsigned long clint_offset = CLINT_MSWI_OFFSET;
+ 
+ static const struct fdt_match ipi_mswi_match[] = {
+ 	{ .compatible = "riscv,clint0", .data = &clint_offset },
+diff --git a/lib/utils/reset/fdt_reset_gpio.c b/lib/utils/reset/fdt_reset_gpio.c
+index d28b6f5ba958..bd2c62270645 100644
+--- a/lib/utils/reset/fdt_reset_gpio.c
++++ b/lib/utils/reset/fdt_reset_gpio.c
+@@ -149,7 +149,7 @@ static int gpio_reset_init(void *fdt, int nodeoff,
+ }
+ 
+ static const struct fdt_match gpio_poweroff_match[] = {
+-	{ .compatible = "gpio-poweroff", .data = (void *)FALSE },
++	{ .compatible = "gpio-poweroff", .data = (const void *)FALSE },
+ 	{ },
+ };
+ 
+@@ -159,7 +159,7 @@ struct fdt_reset fdt_poweroff_gpio = {
+ };
+ 
+ static const struct fdt_match gpio_reset_match[] = {
+-	{ .compatible = "gpio-restart", .data = (void *)TRUE },
++	{ .compatible = "gpio-restart", .data = (const void *)TRUE },
+ 	{ },
+ };
+ 
+-- 
+2.25.1
+

--- a/recipes-bsp/opensbi/files/0002-lib-utils-timer-Add-a-separate-compatible-for-the-D1.patch
+++ b/recipes-bsp/opensbi/files/0002-lib-utils-timer-Add-a-separate-compatible-for-the-D1.patch
@@ -1,0 +1,146 @@
+From c9024b561c01aa469bed3c2266d78e6ae76882ff Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Sun, 8 Aug 2021 01:18:44 -0500
+Subject: [PATCH 2/2] lib: utils/timer: Add a separate compatible for the D1
+ CLINT
+
+The CLINT in the Allwinner D1 SoC apparently does not support 64-bit
+MMIO access. A property was added to support this quirk (and that
+property was copied to the ACLINT MTIMER code). However, since this
+difference in behavior makes the D1 CLINT incompatible with the SiFive
+CLINT's programming interface, a better solution is to use a separate
+compatible string.
+
+Signed-off-by: Samuel Holland <samuel@sholland.org>
+---
+ docs/platform/thead-c9xx.md        |  4 +--
+ lib/utils/ipi/fdt_ipi_mswi.c       |  1 +
+ lib/utils/timer/fdt_timer_mtimer.c | 39 +++++++++++++++++++-----------
+ 3 files changed, 27 insertions(+), 17 deletions(-)
+
+diff --git a/docs/platform/thead-c9xx.md b/docs/platform/thead-c9xx.md
+index 3490ed50dc88..ced784d13f74 100644
+--- a/docs/platform/thead-c9xx.md
++++ b/docs/platform/thead-c9xx.md
+@@ -52,12 +52,11 @@ DTS Example1: (Single core, eg: Allwinner D1 - c906)
+ 		ranges;
+ 
+ 		clint0: clint@14000000 {
+-			compatible = "riscv,clint0";
++			compatible = "allwinner,sun20i-d1-clint";
+ 			interrupts-extended = <
+ 				&cpu0_intc  3 &cpu0_intc  7
+ 				>;
+ 			reg = <0x0 0x14000000 0x0 0x04000000>;
+-			clint,has-no-64bit-mmio;
+ 		};
+ 
+ 		intc: interrupt-controller@10000000 {
+@@ -163,7 +162,6 @@ DTS Example2: (Multi cores with soc reset-regs)
+ 				&cpu4_intc  3 &cpu4_intc  7
+ 				>;
+ 			reg = <0xff 0xdc000000 0x0 0x04000000>;
+-			clint,has-no-64bit-mmio;
+ 		};
+ 
+ 		intc: interrupt-controller@ffd8000000 {
+diff --git a/lib/utils/ipi/fdt_ipi_mswi.c b/lib/utils/ipi/fdt_ipi_mswi.c
+index 0176941a7d68..af69e161a8b7 100644
+--- a/lib/utils/ipi/fdt_ipi_mswi.c
++++ b/lib/utils/ipi/fdt_ipi_mswi.c
+@@ -54,6 +54,7 @@ static int ipi_mswi_cold_init(void *fdt, int nodeoff,
+ static const unsigned long clint_offset = CLINT_MSWI_OFFSET;
+ 
+ static const struct fdt_match ipi_mswi_match[] = {
++	{ .compatible = "allwinner,sun20i-d1-clint", .data = &clint_offset },
+ 	{ .compatible = "riscv,clint0", .data = &clint_offset },
+ 	{ .compatible = "sifive,clint0", .data = &clint_offset },
+ 	{ .compatible = "riscv,aclint-mswi" },
+diff --git a/lib/utils/timer/fdt_timer_mtimer.c b/lib/utils/timer/fdt_timer_mtimer.c
+index 1ad8508f7a02..e140567e9c76 100644
+--- a/lib/utils/timer/fdt_timer_mtimer.c
++++ b/lib/utils/timer/fdt_timer_mtimer.c
+@@ -15,6 +15,11 @@
+ 
+ #define MTIMER_MAX_NR			16
+ 
++struct timer_mtimer_quirks {
++	unsigned int	mtime_offset;
++	bool		has_64bit_mmio;
++};
++
+ static unsigned long mtimer_count = 0;
+ static struct aclint_mtimer_data mtimer[MTIMER_MAX_NR];
+ static struct aclint_mtimer_data *mt_reference = NULL;
+@@ -23,7 +28,7 @@ static int timer_mtimer_cold_init(void *fdt, int nodeoff,
+ 				  const struct fdt_match *match)
+ {
+ 	int i, rc;
+-	unsigned long offset, addr[2], size[2];
++	unsigned long addr[2], size[2];
+ 	struct aclint_mtimer_data *mt;
+ 
+ 	if (MTIMER_MAX_NR <= mtimer_count)
+@@ -43,28 +48,25 @@ static int timer_mtimer_cold_init(void *fdt, int nodeoff,
+ 		return rc;
+ 
+ 	if (match->data) { /* SiFive CLINT */
++		const struct timer_mtimer_quirks *quirks = match->data;
++
+ 		/* Set CLINT addresses */
+ 		mt->mtimecmp_addr = addr[0] + ACLINT_DEFAULT_MTIMECMP_OFFSET;
+ 		mt->mtimecmp_size = ACLINT_DEFAULT_MTIMECMP_SIZE;
+ 		mt->mtime_addr = addr[0] + ACLINT_DEFAULT_MTIME_OFFSET;
+ 		mt->mtime_size = size[0] - mt->mtimecmp_size;
+ 		/* Adjust MTIMER address and size for CLINT device */
+-		offset = *((unsigned long *)match->data);
+-		mt->mtime_addr += offset;
+-		mt->mtimecmp_addr += offset;
+-		mt->mtime_size -= offset;
+-		/* Parse additional CLINT properties */
+-		if (fdt_getprop(fdt, nodeoff, "clint,has-no-64bit-mmio", &rc))
+-			mt->has_64bit_mmio = false;
++		mt->mtime_addr += quirks->mtime_offset;
++		mt->mtimecmp_addr += quirks->mtime_offset;
++		mt->mtime_size -= quirks->mtime_offset;
++		/* Apply additional CLINT quirks */
++		mt->has_64bit_mmio = quirks->has_64bit_mmio;
+ 	} else { /* RISC-V ACLINT MTIMER */
+ 		/* Set ACLINT MTIMER addresses */
+ 		mt->mtime_addr = addr[0];
+ 		mt->mtime_size = size[0];
+ 		mt->mtimecmp_addr = addr[1];
+ 		mt->mtimecmp_size = size[1];
+-		/* Parse additional ACLINT MTIMER properties */
+-		if (fdt_getprop(fdt, nodeoff, "mtimer,no-64bit-mmio", &rc))
+-			mt->has_64bit_mmio = false;
+ 	}
+ 
+ 	/* Check if MTIMER device has shared MTIME address */
+@@ -107,11 +109,20 @@ static int timer_mtimer_cold_init(void *fdt, int nodeoff,
+ 	return 0;
+ }
+ 
+-static unsigned long clint_offset = CLINT_MTIMER_OFFSET;
++static const struct timer_mtimer_quirks d1_clint_quirks = {
++	.mtime_offset	= CLINT_MTIMER_OFFSET,
++	.has_64bit_mmio	= false,
++};
++
++static const struct timer_mtimer_quirks sifive_clint_quirks = {
++	.mtime_offset	= CLINT_MTIMER_OFFSET,
++	.has_64bit_mmio	= true,
++};
+ 
+ static const struct fdt_match timer_mtimer_match[] = {
+-	{ .compatible = "riscv,clint0", .data = &clint_offset },
+-	{ .compatible = "sifive,clint0", .data = &clint_offset },
++	{ .compatible = "allwinner,sun20i-d1-clint", .data = &d1_clint_quirks },
++	{ .compatible = "riscv,clint0", .data = &sifive_clint_quirks },
++	{ .compatible = "sifive,clint0", .data = &sifive_clint_quirks },
+ 	{ .compatible = "riscv,aclint-mtimer" },
+ 	{ },
+ };
+-- 
+2.25.1
+

--- a/recipes-bsp/opensbi/opensbi_%.bbappend
+++ b/recipes-bsp/opensbi/opensbi_%.bbappend
@@ -1,0 +1,10 @@
+# Mainline OpenSBI supports the C906 out of the box, but it needs a few tweaks
+# and a new reset driver for the sunxi watchdog.
+FILESEXTRAPATHS:prepend:nezha := "${THISDIR}/files:"
+
+SRC_URI:append:nezha = " \
+    file://0001-lib-utils-fdt-Require-match-data-to-be-const.patch \
+    file://0002-lib-utils-timer-Add-a-separate-compatible-for-the-D1.patch \
+"
+
+INSANE_SKIP:${PN}:nezha += "ldflags"

--- a/recipes-bsp/u-boot/u-boot-nezha.bb
+++ b/recipes-bsp/u-boot/u-boot-nezha.bb
@@ -1,0 +1,49 @@
+require recipes-bsp/u-boot/u-boot-common.inc
+require recipes-bsp/u-boot/u-boot.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = " \
+    git://github.com/tekkamanninja/u-boot.git;protocol=https;branch=allwinner_d1 \
+    file://0001-sun20i-set-CONFIG_SYS_BOOTM_LEN.patch \
+    file://0001-riscv-fix-build-with-binutils-2.38.patch \
+    file://tftp-mmc-boot.txt \
+    file://uEnv-nezha.txt \
+    file://toc.cfg \
+"
+
+SRCREV = "6db9960b2443ef84b88a573cb5817f8e0ef3712e"
+
+DEPENDS:append = " u-boot-tools-native python3-setuptools-native"
+
+# Overwrite this for your server
+TFTP_SERVER_IP ?= "127.0.0.1"
+
+do_make_toc1_image[depends] = "opensbi:do_deploy"
+
+do_configure:prepend() {
+    sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${WORKDIR}/tftp-mmc-boot.txt
+    mkimage -O linux -T script -C none -n "U-Boot boot script" \
+        -d ${WORKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
+}
+
+# boot0 expects to load a TOC1 image containing OpenSBI and U-Boot
+# (and a DTB). This is similar to, but incompatible with, mainline U-Boot
+# SPL, which expects a FIT image.
+do_make_toc1_image() {
+    cd ${B}
+    cp ${DEPLOY_DIR_IMAGE}/fw_dynamic.bin ${B}
+    ${B}/tools/mkimage -T sunxi_toc1 -d ${WORKDIR}/toc.cfg ${B}/u-boot.toc1
+}
+
+do_deploy:append() {
+    install -m 644 ${B}/u-boot.toc1 ${DEPLOYDIR}
+    install -m 644 ${WORKDIR}/uEnv-nezha.txt ${DEPLOYDIR}/uEnv.txt
+}
+
+COMPATIBLE_MACHINE = "(nezha-allwinner-d1)"
+
+TOOLCHAIN = "gcc"
+
+addtask do_make_toc1_image before do_deploy after do_compile

--- a/recipes-bsp/u-boot/u-boot-nezha/0001-riscv-fix-build-with-binutils-2.38.patch
+++ b/recipes-bsp/u-boot/u-boot-nezha/0001-riscv-fix-build-with-binutils-2.38.patch
@@ -1,0 +1,57 @@
+From eb6f18cc6ee4a3902c373c4bb505c7fcc3450615 Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Thu, 24 Mar 2022 00:23:14 +0100
+Subject: [PATCH] riscv: fix build with binutils 2.38
+
+Original patch:
+https://lore.kernel.org/all/YhCvlHomlT2js3uO@ubuntu01/T/
+
+From version 2.38, binutils default to ISA spec version 20191213. This
+means that the csr read/write (csrr*/csrw*) instructions and fence.i
+instruction has separated from the `I` extension, become two standalone
+extensions: Zicsr and Zifencei.
+
+The fix is to specify those extensions explicitely in -march. However as
+older binutils version do not support this, we first need to detect
+that.
+
+Fixes:
+| cache.c: Assembler messages:
+| cache.c:12: Error: unrecognized opcode `fence.i'
+| arch/riscv/cpu/mtrap.S: Assembler messages:
+| arch/riscv/cpu/mtrap.S:65: Error: unrecognized opcode `csrr a0,scause'
+| arch/riscv/cpu/mtrap.S:66: Error: unrecognized opcode `csrr a1,sepc'
+| arch/riscv/cpu/mtrap.S:67: Error: unrecognized opcode `csrr a2,stval'
+| arch/riscv/cpu/mtrap.S:70: Error: unrecognized opcode `csrw sepc,a0'
+
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+---
+ arch/riscv/Makefile | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/arch/riscv/Makefile b/arch/riscv/Makefile
+index 0b80eb8d8645..6b3dc6e514d8 100644
+--- a/arch/riscv/Makefile
++++ b/arch/riscv/Makefile
+@@ -24,8 +24,16 @@ ifeq ($(CONFIG_CMODEL_MEDANY),y)
+ 	CMODEL = medany
+ endif
+ 
+-ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_C) -mabi=$(ABI) \
+-	     -mcmodel=$(CMODEL)
++RISCV_MARCH = $(ARCH_BASE)$(ARCH_A)$(ARCH_C)
++
++# Newer binutils versions default to ISA spec version 20191213 which moves some
++# instructions from the I extension to the Zicsr and Zifencei extensions.
++toolchain-need-zicsr-zifencei := $(call cc-option-yn, -mabi=$(ABI) -march=$(RISCV_MARCH)_zicsr_zifencei)
++ifeq ($(toolchain-need-zicsr-zifencei),y)
++	RISCV_MARCH := $(RISCV_MARCH)_zicsr_zifencei
++endif
++
++ARCH_FLAGS = -march=$(RISCV_MARCH) -mabi=$(ABI) -mcmodel=$(CMODEL)
+ 
+ PLATFORM_CPPFLAGS	+= $(ARCH_FLAGS)
+ CFLAGS_EFI		+= $(ARCH_FLAGS)
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-nezha/0001-sun20i-set-CONFIG_SYS_BOOTM_LEN.patch
+++ b/recipes-bsp/u-boot/u-boot-nezha/0001-sun20i-set-CONFIG_SYS_BOOTM_LEN.patch
@@ -1,0 +1,28 @@
+From 1af97b277b52f41968fed161f88551c1fd85e1d4 Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Sun, 14 Nov 2021 00:04:45 +0100
+Subject: [PATCH] sun20i: set CONFIG_SYS_BOOTM_LEN
+
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+---
+ include/configs/sun20i.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/include/configs/sun20i.h b/include/configs/sun20i.h
+index f463d289bd16..d9a33bfb8b62 100644
+--- a/include/configs/sun20i.h
++++ b/include/configs/sun20i.h
+@@ -2,6 +2,10 @@
+ 
+ #define CONFIG_SYS_CACHELINE_SIZE	64
+ 
++#ifdef CONFIG_RISCV
++#define CONFIG_SYS_BOOTM_LEN		(32 << 20)
++#endif
++
+ /* FIXME: Need a real clock driver! */
+ #define CONFIG_SYS_NS16550_CLK		24000000
+ #define CONFIG_SYS_TCLK			24000000
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-nezha/toc.cfg
+++ b/recipes-bsp/u-boot/u-boot-nezha/toc.cfg
@@ -1,0 +1,9 @@
+[opensbi]
+file = fw_dynamic.bin
+addr = 0x40000000
+[dtb]
+file = u-boot.dtb
+addr = 0x44000000
+[u-boot]
+file = u-boot.bin
+addr = 0x4a000000

--- a/recipes-bsp/u-boot/u-boot-nezha/uEnv-nezha.txt
+++ b/recipes-bsp/u-boot/u-boot-nezha/uEnv-nezha.txt
@@ -1,0 +1,4 @@
+bootargs=earlycon=sbi clk_ignore_unused initcall_debug=0 console=ttyS0,115200 loglevel=8 root=/dev/mmcblk0p2 rootwait  init=/sbin/init
+bootcmd_load_f=load ${devtype} ${devnum}:${distro_bootpart} ${ramdisk_addr_r} fitImage
+bootcmd_run=bootm ${ramdisk_addr_r} - ${fdtcontroladdr}
+bootcmd=run bootcmd_load_f; run bootcmd_run

--- a/recipes-kernel/linux/linux-nezha-dev.bb
+++ b/recipes-kernel/linux/linux-nezha-dev.bb
@@ -1,0 +1,29 @@
+require recipes-kernel/linux/linux-mainline-common.inc
+FILESEXTRAPATHS:prepend = "${FILE_DIRNAME}/linux-nezha:"
+SUMMARY = "Nezha dev kernel recipe"
+
+SRCREV_meta ?= "ea948a0983d7b7820814e5bce4eda3079201bd95"
+SRCREV_machine ?= "af3f4a1caec12845b809fba959e6334ab3b52a40"
+FORK ?= "tekkamanninja"
+BRANCH ?= "allwinner_nezha_d1_devel"
+KMETA = "kernel-meta"
+
+# It is necessary to add to SRC_URI link to the 'yocto-kernel-cache' due to
+# override of the original SRC_URI:
+# "do_kernel_metadata: Check the SRC_URI for meta-data repositories or
+# directories that may be missing"
+SRC_URI = " \
+        git://github.com/${FORK}/linux.git;name=machine;protocol=https;branch=${BRANCH} \
+        git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=${KMETA} \
+        file://0001-riscv-fix-build-with-binutils-2.38.patch \
+    "
+
+LINUX_VERSION ?= "5.16.0"
+LINUX_VERSION_EXTENSION:append = "-nezha"
+
+KERNEL_FEATURES += "features/cgroups/cgroups.cfg"
+KERNEL_FEATURES += "ktypes/standard/standard.cfg"
+
+KBUILD_DEFCONFIG = "nezha_defconfig"
+
+COMPATIBLE_MACHINE = "(nezha-allwinner-d1)"

--- a/recipes-kernel/linux/linux-nezha/0001-riscv-fix-build-with-binutils-2.38.patch
+++ b/recipes-kernel/linux/linux-nezha/0001-riscv-fix-build-with-binutils-2.38.patch
@@ -1,0 +1,55 @@
+From 46602fe7729b285a823a1bab49d5f77e643be021 Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Wed, 23 Mar 2022 23:34:37 +0100
+Subject: [PATCH] riscv: fix build with binutils 2.38
+
+Original source of this patch:
+- https://lore.kernel.org/lkml/YgVRu9Z0BDyJdjR5@kroah.com/T/
+
+From version 2.38, binutils default to ISA spec version 20191213. This
+means that the csr read/write (csrr*/csrw*) instructions and fence.i
+instruction has separated from the `I` extension, become two standalone
+extensions: Zicsr and Zifencei. As the kernel uses those instruction,
+this causes the following build failure:
+
+  CC      arch/riscv/kernel/vdso/vgettimeofday.o
+  <<BUILDDIR>>/arch/riscv/include/asm/vdso/gettimeofday.h: Assembler messages:
+  <<BUILDDIR>>/arch/riscv/include/asm/vdso/gettimeofday.h:71: Error: unrecognized opcode `csrr a5,0xc01'
+  <<BUILDDIR>>/arch/riscv/include/asm/vdso/gettimeofday.h:71: Error: unrecognized opcode `csrr a5,0xc01'
+  <<BUILDDIR>>/arch/riscv/include/asm/vdso/gettimeofday.h:71: Error: unrecognized opcode `csrr a5,0xc01'
+  <<BUILDDIR>>/arch/riscv/include/asm/vdso/gettimeofday.h:71: Error: unrecognized opcode `csrr a5,0xc01'
+
+The fix is to specify those extensions explicitely in -march. However as
+older binutils version do not support this, we first need to detect
+that.
+
+Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>
+Tested-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+---
+ arch/riscv/Makefile | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/riscv/Makefile b/arch/riscv/Makefile
+index 8a107ed18b0d..7d81102cffd4 100644
+--- a/arch/riscv/Makefile
++++ b/arch/riscv/Makefile
+@@ -50,6 +50,12 @@ riscv-march-$(CONFIG_ARCH_RV32I)	:= rv32ima
+ riscv-march-$(CONFIG_ARCH_RV64I)	:= rv64ima
+ riscv-march-$(CONFIG_FPU)		:= $(riscv-march-y)fd
+ riscv-march-$(CONFIG_RISCV_ISA_C)	:= $(riscv-march-y)c
++
++# Newer binutils versions default to ISA spec version 20191213 which moves some
++# instructions from the I extension to the Zicsr and Zifencei extensions.
++toolchain-need-zicsr-zifencei := $(call cc-option-yn, -march=$(riscv-march-y)_zicsr_zifencei)
++riscv-march-$(toolchain-need-zicsr-zifencei) := $(riscv-march-y)_zicsr_zifencei
++
+ KBUILD_CFLAGS += -march=$(subst fd,,$(riscv-march-y))
+ KBUILD_AFLAGS += -march=$(riscv-march-y)
+ 
+-- 
+2.25.1
+

--- a/wic/nezha.wks
+++ b/wic/nezha.wks
@@ -1,0 +1,9 @@
+# short-description: Create SD card image for Nezha Allwinner D1 development board
+
+part boot0 --source rawcopy --sourceparams="file=boot0_sdcard_sun20iw1p1.bin" --offset 16s --ondisk mmcblk0 --no-table
+
+part u-boot --source rawcopy --sourceparams="file=u-boot.toc1" --offset 32800s --ondisk mmcblk0 --no-table
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --align 4096 --fixed-size 64 --active
+
+part /     --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs  --align 4096 --fixed-size 14000 --exclude-path data/


### PR DESCRIPTION
This PR provides early support to the Nezha Allwinner D1 board. It uses **dev** versions of the Linux kernel, U-Boot and OpenSBI. This version was checked and it builds with success.

Key changes:
**- nezha.yml: add file used with kas-docker**

**- linux-nezha-dev | u-boot-nezha | boot0: add patch which fix build with binutils 2.28**

**- nezha.wks: description of SD card image for Nezha D1 development board**

**- linux-nezha-dev: use custom version of kernel with paches for D1 chip**

**- u-boot-nezha: add patch which fix build with binutils 2.28**

**- u-boot-nezha: add patch which increases the CONFIF_SYS_BOOTM_LEN**

**- toc.cfg: add configuration file of TOC1 U-Boot image**

**- uEnv-nezha.txt: U-Boot bootargs for Nezha board**

**- u-boot-nezha.bb: add recipe with patches for Nezha board**

**- opensbi: update mainline with patches to fit Nezha board**

**- boot0: add patch which fix build with binutils 2.28**

**- boot0: add patch for Makefile to fit it with yocto build environment**

**- boot0.bb: add recipe of the Nezha SPL**

**- nezha-allwinner-d1.conf: add machine configuration for Nezha board**
 
External resources:
- [linux-sunxi](https://linux-sunxi.org/Allwinner_Nezha)
- [meta-nezha](https://github.com/Cezarus27/meta-nezha)
- [Nezha SBC first impression](https://blog.3mdeb.com/2021/2021-11-19-nezha-riscv-sbc-first-impression/)

Known issues:
- no support of the WiFi&BT driver `XR829` in the currently used kernel
- `rng-tools` not working. For some reason, it crushes during the start with `SIGSEGV` in `libc`. This problem doesn't exist when the `haveged` random number generator is used in the build.

**Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>**