### PR TITLE
apache2: Ignore textrels on rv64

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -52,6 +52,8 @@ INSANE_SKIP:append:pn-fish:riscv64 = " textrel"
 INSANE_SKIP:append:pn-lttng-tools:riscv64 = " textrel"
 INSANE_SKIP:append:pn-gn:riscv64 = " textrel"
 INSANE_SKIP:append:pn-apitrace:riscv64 = " textrel"
+INSANE_SKIP:append:pn-apache2:riscv64 = " textrel"
+INSANE_SKIP:append:pn-go:riscv64 = " textrel"
 # Seen with musl+clang13
 INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv64 = " textrel"
 
@@ -81,6 +83,8 @@ INSANE_SKIP:append:pn-cmocka:riscv32 = " textrel"
 INSANE_SKIP:append:pn-util-linux:riscv32 = " textrel"
 INSANE_SKIP:append:pn-apitrace:riscv32 = " textrel"
 INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv32 = " textrel"
+INSANE_SKIP:append:pn-apache2:riscv32 = " textrel"
+INSANE_SKIP:append:pn-go:riscv32 = " textrel"
 
 # These recipe dont _yet_ build for rv32
 COMPATIBLE_HOST:pn-openh264:riscv32 = "null"


### PR DESCRIPTION
Fixes
ERROR: apache2-2.4.53-r0 do_package_qa: QA Issue: apache2: ELF binary /usr/sbin/httpd has relocations in .text [textrel]
ERROR: apache2-2.4.53-r0 do_package_qa: Fatal QA errors were found, failing task.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

