### PR TITLE
recipes-kernel: linux: Set SRCPV and PV

### DIFF
--- a/recipes-kernel/linux/linux-mainline_5.17.bb
+++ b/recipes-kernel/linux/linux-mainline_5.17.bb
@@ -1,10 +1,12 @@
 require recipes-kernel/linux/linux-mainline-common.inc
 
-LINUX_VERSION ?= "5.17.x"
+LINUX_VERSION ?= "5.17+"
 KERNEL_VERSION_SANITY_SKIP="1"
+PV = "${LINUX_VERSION}+git${SRCPV}"
 
 BRANCH = "linux-5.17.y"
 SRCREV = "${AUTOREV}"
+SRCPV = "${@bb.fetch2.get_srcrev(d)}"
 SRC_URI = " \
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;branch=${BRANCH} \
 "


### PR DESCRIPTION
Set SRCPV and PV, this avoids errors when using devtool with the
linux-mainline.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>