### PR TITLE
libcereal: Skip textrel QA check on rv32

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ OpenEmbedded/Yocto distributions and layer stacks, such as:
 
 This layer depends on:
 
-* URI: git://github.com/openembedded/openembedded-core
+* URI: https://github.com/openembedded/openembedded-core
   * branch: master
   * revision: HEAD
-* URI: git://github.com/openembedded/bitbake
+* URI: https://github.com/openembedded/bitbake
   * branch: master
   * revision: HEAD
 
@@ -37,7 +37,7 @@ Make sure to [install the `repo` command by Google](https://source.android.com/s
 ### Create workspace
 ```text
 mkdir riscv-yocto && cd riscv-yocto
-repo init -u git://github.com/riscv/meta-riscv  -b master -m tools/manifests/riscv-yocto.xml
+repo init -u https://github.com/riscv/meta-riscv  -b master -m tools/manifests/riscv-yocto.xml
 repo sync
 repo start work --all
 ```

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -56,6 +56,7 @@ INSANE_SKIP:append:pn-apache2:riscv64 = " textrel"
 INSANE_SKIP:append:pn-go:riscv64 = " textrel"
 # Seen with musl+clang13
 INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv64 = " textrel"
+INSANE_SKIP:append:pn-libcereal:riscv64 = " textrel"
 
 INSANE_SKIP:append:pn-xfsdump:riscv32 = " textrel"
 INSANE_SKIP:append:pn-zabbix:riscv32 = " textrel"
@@ -85,6 +86,7 @@ INSANE_SKIP:append:pn-apitrace:riscv32 = " textrel"
 INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv32 = " textrel"
 INSANE_SKIP:append:pn-apache2:riscv32 = " textrel"
 INSANE_SKIP:append:pn-go:riscv32 = " textrel"
+INSANE_SKIP:append:pn-libcereal:riscv32 = " textrel"
 
 # These recipe dont _yet_ build for rv32
 COMPATIBLE_HOST:pn-openh264:riscv32 = "null"

--- a/docs/Plasma-Mobile-on-Unleashed.md
+++ b/docs/Plasma-Mobile-on-Unleashed.md
@@ -8,22 +8,22 @@ Written by: Alistair Francis <alistair.francis@wdc.com>
 
 To build plasma mobile you will need (as well as meta-riscv):
 
-* URI: git://github.com/openembedded/openembedded-core
+* URI: https://github.com/openembedded/openembedded-core
   * branch: master
   * revision: HEAD
-* URI: git://github.com/openembedded/bitbake
+* URI: https://github.com/openembedded/bitbake
   * branch: master
   * revision: HEAD
-* URI: git://git.yoctoproject.org/meta-java
+* URI: https://git.yoctoproject.org/meta-java
   * branch: master
   * revision: HEAD
-* URI: git://github.com/meta-qt5/meta-qt5.git
+* URI: https://github.com/meta-qt5/meta-qt5.git
   * branch: master
   * revision: HEAD
-* URI: git://github.com/KDE/yocto-meta-kf5.git
+* URI: https://github.com/KDE/yocto-meta-kf5.git
   * branch: master
   * revision: HEAD
-* URI: git://github.com/KDE/yocto-meta-kde.git
+* URI: https://github.com/KDE/yocto-meta-kde.git
   * branch: master
   * revision: HEAD
 

--- a/dynamic-layers/openembedded-layer/recipes-devtools/openocd/openocd_riscv.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/openocd/openocd_riscv.bb
@@ -3,7 +3,7 @@ require recipes-devtools/openocd/openocd_git.bb
 PV = "riscv"
 
 SRC_URI = " \
-    git://github.com/riscv/riscv-openocd.git;protocol=http;branch=riscv;name=openocd \
+    git://github.com/riscv/riscv-openocd.git;protocol=https;branch=riscv;name=openocd \
     git://repo.or.cz/r/git2cl.git;protocol=http;destsuffix=tools/git2cl;name=git2cl \
     git://repo.or.cz/r/jimtcl.git;protocol=http;destsuffix=git/jimtcl;name=jimtcl \
     git://repo.or.cz/r/libjaylink.git;protocol=http;destsuffix=git/src/jtag/drivers/libjaylink;name=libjaylink \

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
@@ -3,7 +3,7 @@ require recipes-bsp/u-boot/u-boot.inc
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=git;branch=Fedora_VIC_7100_2021.04 \
+SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;branch=Fedora_VIC_7100_2021.04 \
            file://tftp-mmc-boot.txt \
            file://977abc529f98c1c90a80ad280fe9e58ddd43c87a.patch \
            file://2feaab2bd04ed736c637518b3b553615f0c97890.patch \

--- a/recipes-devtools/riscv-tools/riscv-fesvr.bb
+++ b/recipes-devtools/riscv-tools/riscv-fesvr.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.GPLv2;md5=751419260aa954499f7abaabaa882bbe"
 
 SRCREV = "8d108a0a647901550d95925549337c2c3aec9ac8"
-SRC_URI = "git://github.com/riscv/riscv-fesvr.git \
+SRC_URI = "git://github.com/riscv/riscv-fesvr.git;protocol=https;branch=master \
            file://fesvr-makefile.patch"
 
 inherit autotools gettext cross-canadian

--- a/recipes-devtools/riscv-tools/riscv-spike.bb
+++ b/recipes-devtools/riscv-tools/riscv-spike.bb
@@ -5,7 +5,7 @@ LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.GPLv2;md5=751419260aa954499f7abaabaa882bbe"
 
 SRCREV = "65c8ac48af16235097084b413c10c7bff576b331"
-SRC_URI = "git://github.com/riscv/riscv-isa-sim.git \
+SRC_URI = "git://github.com/riscv-software-src/riscv-isa-sim;protocol=https;branch=master \
            file://spike-makefile.patch"
 
 DEPENDS = "riscv-fesvr dtc-native"

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -8,7 +8,7 @@ KERNEL_VERSION_SANITY_SKIP = "1"
 SRCREV = "${AUTOREV}"
 FORK ?= "starfive-tech"
 BRANCH ?= "esmil_starlight"
-SRC_URI = "git://github.com/${FORK}/linux.git;protocol=git;branch=${BRANCH} \
+SRC_URI = "git://github.com/${FORK}/linux.git;protocol=https;branch=${BRANCH} \
            file://0001-riscv-Use-mno-relax-when-using-lld-linker.patch \
            file://extra.cfg \
            file://modules.cfg \

--- a/recipes-kernel/linux/linux-starfive_5.12.bb
+++ b/recipes-kernel/linux/linux-starfive_5.12.bb
@@ -3,7 +3,7 @@ SUMMARY = "An example kernel recipe that uses the linux-yocto and oe-core"
 inherit kernel
 require recipes-kernel/linux/linux-yocto.inc
 
-SRC_URI = "git://github.com/esmil/linux.git;protocol=git;branch=starlight-5.12.y \
+SRC_URI = "git://github.com/esmil/linux.git;protocol=https;branch=starlight-5.12.y \
            file://0001-riscv-Use-mno-relax-when-using-lld-linker.patch \
            file://extra.cfg \
            file://modules.cfg \


### PR DESCRIPTION
Fixes
QA Issue: libcereal-ptest: ELF binary /usr/lib/libcereal/ptest/tests/test_unordered_multimap has relocations in .text

