### PR TITLE
linux-mainline: bump to 5.18

### DIFF
--- a/recipes-kernel/linux/linux-mainline_5.18.bb
+++ b/recipes-kernel/linux/linux-mainline_5.18.bb
@@ -1,10 +1,10 @@
 require recipes-kernel/linux/linux-mainline-common.inc
 
-LINUX_VERSION ?= "5.17+"
+LINUX_VERSION ?= "5.18+"
 KERNEL_VERSION_SANITY_SKIP="1"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-BRANCH = "linux-5.17.y"
+BRANCH = "linux-5.18.y"
 SRCREV = "${AUTOREV}"
 SRCPV = "${@bb.fetch2.get_srcrev(d)}"
 SRC_URI = " \


### PR DESCRIPTION
715066a79ea9 riscv: use fallback for random_get_entropy() instead of zero
f4e9fe58d4af riscv: use fallback for random_get_entropy() instead of zero
dcd042ccae9e riscv: dts: sifive: fu540-c000: align dma node name with dtschema
265f34c25bad Merge tag 'riscv-for-linus-5.18-rc8' of git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux
c932edeaf6d6 riscv: dts: microchip: fix gpio1 reg property typo
b17410182b6f riscv: dts: sifive: fu540-c000: align dma node name with dtschema
26b29404d15c riscv: patch_text: Fixup last cpu should be master
497fe3bb196d Merge tag 'riscv-for-linus-5.18-rc6' of git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux
2d0de93ca251 Merge tag 'riscv-for-linus-5.18-rc5' of git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux
6deb9bf4580d riscv: dts: microchip: reparent mpfs clocks
2b6190c80423 riscv: dts: microchip: fix usage of fic clocks on mpfs
4e339e5e2dbf Merge tag 'riscv-for-linus-5.18-rc4' of git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux
8ec1442953c6 riscv: patch_text: Fixup last cpu should be master
012c722569f1 Merge tag 'kvm-riscv-fixes-5.18-2' of https://github.com/kvm-riscv/linux into HEAD
fb80e2399d64 KVM: selftests: riscv: Fix alignment of the guest_hang() function
590fe86a80c5 KVM: selftests: riscv: Set PTE A and D bits in VS-stage page table
f81f7861ee2a cpuidle: riscv: support non-SMP config
6bf639ea14dd riscv: Fixed misaligned memory access. Fixed pointer comparison.
b2c2c21a7d78 Merge tag 'kvm-riscv-fixes-5.18-1' of https://github.com/kvm-riscv/linux into HEAD
ebdef0de2dbc KVM: selftests: riscv: Fix alignment of the guest_hang() function
fac372536439 KVM: selftests: riscv: Set PTE A and D bits in VS-stage page table
559ea0f38b7e riscv module: remove (NOLOAD)
e9eb8f04560f libbpf: Fix riscv register names
b91e1db8a8fa riscv: Increase stack size under KASAN
bd0dfce1e337 riscv: Fix fill_callchain return value
eccd1ac12425 riscv: dts: canaan: Fix SPI3 bus width
1fdff407028c Merge tag 'riscv-for-linus-5.18-mw2' of git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux
a3dfc532b873 Merge tag 'riscv-for-linus-5.18-mw1' of git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux
8933e7f2e375 Documentation: riscv: remove non-existent directory from table of contents
e634ff7733ba riscv: cpu.c: don't use kernel-doc markers for comments
617487600b94 RISC-V: module: fix apply_r_riscv_rcv_branch_rela typo
8a122a66c770 RISC-V: Fix a comment typo in riscv_of_parent_hartid()
b81d591386c3 riscv: Increase stack size under KASAN
2b2b574ac587 riscv: Fix fill_callchain return value
6846d656106a riscv: dts: canaan: Fix SPI3 bus width
fdecfea09328 riscv: Rename "sp_in_global" to "current_stack_pointer"
60210a3d86dc riscv module: remove (NOLOAD)
aa5b537b0ecc Merge tag 'riscv-for-linus-5.18-mw0' of git://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux
d414cb379ac3 riscv: mm: init: use IS_ENABLED(CONFIG_KEXEC_CORE) instead of #ifdef
23b1f18326ec Documentation: riscv: Remove the old documentation
40a4d0dfbcf0 RISC-V: Extract multi-letter extension names from "riscv, isa"
2a31c54be097 RISC-V: Minimal parser for "riscv, isa" strings
990d627f80c3 riscv: dts: Change the macro name of prci in each device node
cf5019816d87 Merge tag 'kvm-riscv-5.18-1' of https://github.com/kvm-riscv/linux into HEAD
c9d3b5bd2693 RISC-V: KVM: Add common kvm_riscv_vcpu_wfi() function
4b11d86571c4 RISC-V: KVM: Add common kvm_riscv_vcpu_sbi_system_reset() function
823f53a30eb0 RISC-V: KVM: Refine __kvm_riscv_switch_to() implementation
afec0c65d09d KVM: compat: riscv: Prevent KVM_COMPAT from being selected
9d1f0ec9f717 riscv: Fixed misaligned memory access. Fixed pointer comparison.
48e8641c2bf0 MAINTAINERS: update riscv/microchip entry
528a5b1f2556 riscv: dts: microchip: add new peripherals to icicle kit device tree
5b28df37d311 riscv: dts: microchip: update peripherals in icicle kit device tree
c5094f371008 riscv: dts: microchip: refactor icicle kit device tree
72560c6559b8 riscv: dts: microchip: add fpga fabric section to icicle kit
6546f920868e riscv: dts: microchip: use clk defines for icicle kit
125c0d0bec56 docs/zh_CN: add riscv vm-layout translation
d56201d9440d riscv: defconfig: enable hugetlbfs option
8fbdccd2b173 riscv: mm: Support kasan for sv57
011f09d12052 riscv: mm: Set sv57 on defaultly
677b9eb8810e riscv: mm: Prepare pt_ops helper functions for sv57
d10efa21a937 riscv: mm: Control p4d's folding by pgtable_l5_enabled
67ff2f262619 riscv: mm: init: mark satp_mode __ro_after_init
cf0b5b276923 libbpf: Fix accessing syscall arguments on riscv
5c101153bfd6 libbpf: Fix riscv register names

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

