### PR TITLE
minio: Skip textrel QA error

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -60,6 +60,7 @@ INSANE_SKIP:append:pn-go:riscv64 = " textrel"
 # Seen with musl+clang13
 INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv64 = " textrel"
 INSANE_SKIP:append:pn-libcereal:riscv64 = " textrel"
+INSANE_SKIP:append:pn-minio:riscv64 = " textrel"
 
 INSANE_SKIP:append:pn-xfsdump:riscv32 = " textrel"
 INSANE_SKIP:append:pn-zabbix:riscv32 = " textrel"
@@ -91,6 +92,7 @@ INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv32 = " textrel"
 INSANE_SKIP:append:pn-apache2:riscv32 = " textrel"
 INSANE_SKIP:append:pn-go:riscv32 = " textrel"
 INSANE_SKIP:append:pn-libcereal:riscv32 = " textrel"
+INSANE_SKIP:append:pn-minio:riscv32 = " textrel"
 
 # These recipe dont _yet_ build for rv32
 COMPATIBLE_HOST:pn-openh264:riscv32 = "null"


### PR DESCRIPTION
Fixes
ERROR: QA Issue: minio: ELF binary /usr/sbin/mc has relocations in .text [textrel]

Signed-off-by: Khem Raj <raj.khem@gmail.com>

