### PR TITLE
u-boot: starfive_v2021.04: Override the u-boot LIC_FILES_CHKSUM

### DIFF
--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
@@ -1,6 +1,8 @@
 require recipes-bsp/u-boot/u-boot-common.inc
 require recipes-bsp/u-boot/u-boot.inc
 
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 BRANCH:visionfive = "JH7100_VisionFive_OH_dev"


### PR DESCRIPTION
The LIC_FILES_CHKSUM md5sum changed with the latest mainline u-boot
release, but hasn't changed for the older starfive release. So manually
specify the original md5sum value.

Resolves: https://github.com/riscv/meta-riscv/issues/350
Signed-off-by: Alistair Francis <alistair.francis@wdc.com>