### PR TITLE
libnl: Ignore textrel on rv64/rv32

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -61,6 +61,8 @@ INSANE_SKIP:append:pn-go:riscv64 = " textrel"
 INSANE_SKIP:append:pn-jemalloc:toolchain-clang:riscv64 = " textrel"
 INSANE_SKIP:append:pn-libcereal:riscv64 = " textrel"
 INSANE_SKIP:append:pn-minio:riscv64 = " textrel"
+# QA Issue: libnl-ptest: ELF binary /usr/lib/libnl/ptest/check-all has relocations in .text [textrel]
+INSANE_SKIP:append:pn-libnl:riscv64 = " textrel"
 
 INSANE_SKIP:append:pn-xfsdump:riscv32 = " textrel"
 INSANE_SKIP:append:pn-zabbix:riscv32 = " textrel"
@@ -93,6 +95,8 @@ INSANE_SKIP:append:pn-apache2:riscv32 = " textrel"
 INSANE_SKIP:append:pn-go:riscv32 = " textrel"
 INSANE_SKIP:append:pn-libcereal:riscv32 = " textrel"
 INSANE_SKIP:append:pn-minio:riscv32 = " textrel"
+# QA Issue: libnl-ptest: ELF binary /usr/lib/libnl/ptest/check-all has relocations in .text [textrel]
+INSANE_SKIP:append:pn-libnl:riscv32 = " textrel"
 
 # These recipe dont _yet_ build for rv32
 COMPATIBLE_HOST:pn-openh264:riscv32 = "null"


### PR DESCRIPTION
Fixes build QA
ERROR: libnl-1_3.7.0-r0 do_package_qa: QA Issue: libnl-ptest: ELF binary /usr/lib/libnl/ptest/check-all has relocations in .text [textrel]
ERROR: libnl-1_3.7.0-r0 do_package_qa: Fatal QA errors were found, failing task.

Signed-off-by: Khem Raj <raj.khem@gmail.com>

