### PR TITLE
u-boot: nezha: Override the u-boot LIC_FILES_CHKSUM

### DIFF
--- a/recipes-bsp/u-boot/u-boot-nezha.bb
+++ b/recipes-bsp/u-boot/u-boot-nezha.bb
@@ -1,6 +1,8 @@
 require recipes-bsp/u-boot/u-boot-common.inc
 require recipes-bsp/u-boot/u-boot.inc
 
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 


### PR DESCRIPTION
The LIC_FILES_CHKSUM md5sum changed with the latest mainline u-boot release. So manually specify the original md5sum value.

Signed-off-by: Matheus Castello <matheus@castello.eng.br>

