### PR TITLE
u-boot: Add opensbi do_deploy dep only for machines with opensbi

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -44,7 +44,8 @@ do_deploy:append:freedom-u540() {
     fi
 }
 
-do_compile[depends] += "opensbi:do_deploy"
+# Only add opensbi dependency if opensbi is in image deps
+do_compile[depends] += "${@bb.utils.contains('EXTRA_IMAGEDEPENDS', 'opensbi', 'opensbi:do_deploy', '',d)}"
 
 do_compile:prepend:ae350-ax45mp() {
     export OPENSBI=${DEPLOY_DIR_IMAGE}/fw_dynamic.bin


### PR DESCRIPTION
This is a generic bbappend and opensbi is riscv specific, so this causes problems when this layer is includes and a build is done for non-riscv machines e.g.

    MACHINE=qemumips bitbake -n world

will show the problem

ERROR: Nothing PROVIDES 'opensbi'
opensbi was skipped: incompatible with host mips-yoe-linux-musl (not in COMPATIBLE_HOST) NOTE: Runtime target 'u-boot-default-env' is unbuildable, removing... Missing or unbuildable dependency chain was: ['u-boot-default-env', 'opensbi'] ERROR: Required build target 'meta-world-pkgdata' has no buildable providers. Missing or unbuildable dependency chain was: ['meta-world-pkgdata', 'libubootenv', 'u-boot-default-env', 'opensbi']

Signed-off-by: Khem Raj <raj.khem@gmail.com>

