### PR TITLE
Backport linux uboot from master to kirkstone

### DIFF
--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
@@ -1,15 +1,29 @@
 require recipes-bsp/u-boot/u-boot-common.inc
 require recipes-bsp/u-boot/u-boot.inc
 
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;branch=Fedora_VIC_7100_2021.04 \
+BRANCH:visionfive = "JH7100_VisionFive_OH_dev"
+BRANCH:beaglev-starlight-jh7100 = "Fedora_JH7100_2021.04"
+
+SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;branch=${BRANCH} \
            file://tftp-mmc-boot.txt \
-           file://977abc529f98c1c90a80ad280fe9e58ddd43c87a.patch \
-           file://2feaab2bd04ed736c637518b3b553615f0c97890.patch \
           "
 
+SRC_URI:append:beaglev-starlight-jh7100 = " \
+           file://977abc529f98c1c90a80ad280fe9e58ddd43c87a.patch \
+           file://2feaab2bd04ed736c637518b3b553615f0c97890.patch \
+           "
+
+SRC_URI:append:visionfive = " \
+           file://fix-riscv-isa.patch \
+           file://uEnv-visionfive.txt \
+"
+
 SRCREV = "7b70e1d44ba9702a519ca936cabf19070309123a"
+SRCREV:visionfive = "ccecef294d355e9d05edf0bb6058002a0fe08908"
 
 DEPENDS:append = " u-boot-tools-native"
 
@@ -22,6 +36,13 @@ do_configure:prepend() {
         -d ${WORKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
 }
 
-COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100)"
+do_deploy:append:visionfive() {
+    install -m 644 ${WORKDIR}/uEnv-visionfive.txt ${DEPLOYDIR}/uEnv.txt
+}
+
+COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100|visionfive)"
 
 TOOLCHAIN = "gcc"
+
+# U-boot sets O=... which needs it to build outside of S
+B = "${WORKDIR}/build"

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -6,17 +6,17 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 KERNEL_VERSION_SANITY_SKIP = "1"
 
 SRCREV = "${AUTOREV}"
+BRANCH = "visionfive"
 FORK ?= "starfive-tech"
-BRANCH ?= "esmil_starlight"
 SRC_URI = "git://github.com/${FORK}/linux.git;protocol=https;branch=${BRANCH} \
-           file://0001-riscv-Use-mno-relax-when-using-lld-linker.patch \
            file://extra.cfg \
            file://modules.cfg \
           "
 
-LINUX_VERSION ?= "5.14.0"
-LINUX_VERSION_EXTENSION:append = "-starlight"
+LINUX_VERSION ?= "6.0.0"
+LINUX_VERSION_EXTENSION:append:beaglev-starlight-jh7100 = "-starlight"
 
-KBUILD_DEFCONFIG:beaglev-starlight-jh7100 = "beaglev_defconfig"
+KBUILD_DEFCONFIG:beaglev-starlight-jh7100 = "starfive_jh7100_fedora_defconfig"
+KBUILD_DEFCONFIG:visionfive = "visionfive_defconfig"
 
-COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100)"
+COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100|visionfive)"


### PR DESCRIPTION
It fixes the issue:
https://github.com/riscv/meta-riscv/issues/377

I've faced a fetch issue while baking for Kirkstone. So I updated the linux and u-boot recipe to be the same as in master.

Now, it builds for me.

I don't have the hardware, so I cannot test if it works.

Please, let me know if there is a better version to use on kirkstone. 