### PR TITLE
rtl8723ds: Pin to mangopi-mq-pro machine

### DIFF
--- a/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
+++ b/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
@@ -16,3 +16,5 @@ S = "${WORKDIR}/git"
 RPROVIDES:${PN} += "kernel-module-rtl8723ds"
 
 EXTRA_OEMAKE = "KSRC=${STAGING_KERNEL_DIR}"
+
+COMPATIBLE_MACHINE = "mangopi-mq-pro"


### PR DESCRIPTION
It is not intended for all kind of machines by default, other machines can be enabled as needed and verified to work on it.

Signed-off-by: Khem Raj <raj.khem@gmail.com>



