### PR TITLE
Visionfive2: Build bootable SD card image

### DIFF
--- a/conf/machine/visionfive2.conf
+++ b/conf/machine/visionfive2.conf
@@ -55,6 +55,8 @@ UBOOT_ENTRYPOINT = "0x80200000"
 UBOOT_DTB_LOADADDRESS = "0x82200000"
 UBOOT_DTB = "1"
 UBOOT_DTB_BINARY = "starfive_visionfive2.dtb"
+SPL_BINARY = "spl/u-boot-spl.bin"
+SPL_NORMAL_BINARY = "u-boot-spl.bin.normal.out"
 
 ## wic default support
 WKS_FILE_DEPENDS ?= " \
@@ -68,7 +70,7 @@ IMAGE_BOOT_FILES ?= " \
     ${KERNEL_IMAGETYPE} \
     ${RISCV_SBI_FDT}  \
     boot.scr.uimg \
-    uEnv.txt \
+    vf2_uEnv.txt \
 "
 
-WKS_FILE ?= "beaglev.wks"
+WKS_FILE ?= "visionfive2.wks"

--- a/recipes-bsp/jh7110-spl-tool/jh7110-spl-tool_git.bb
+++ b/recipes-bsp/jh7110-spl-tool/jh7110-spl-tool_git.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "spl_tool is a jh7110 signature tool used to generate spl header information and generate u-boot-spl.bin.normal.out."
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e6dc25dc2418b8831c906d43809d8336"
+SECTION = "bootloaders"
+
+SRCREV = "8c5acc4e5eb7e4ad012463b05a5e3dbbfed1c38d"
+SRC_URI = "git://github.com/starfive-tech/Tools;protocol=https;branch=master"
+
+S = "${WORKDIR}/git/spl_tool"
+
+do_compile () {
+    cd ${S}
+    oe_runmake clean
+    oe_runmake
+}
+
+do_install () {
+    install -Dm 0755 ${S}/spl_tool ${D}${bindir}/spl_tool
+}
+
+BBCLASSEXTEND = "native"

--- a/recipes-bsp/opensbi/opensbi/visionfive2-uboot-fit-image.its
+++ b/recipes-bsp/opensbi/opensbi/visionfive2-uboot-fit-image.its
@@ -1,0 +1,28 @@
+/dts-v1/;
+
+/ {
+	description = "U-boot-spl FIT image for JH7110 VisionFive2";
+	#address-cells = <2>;
+
+	images {
+		firmware {
+			description = "u-boot";
+			data = /incbin/("fw_payload.bin");
+			type = "firmware";
+			arch = "riscv";
+			os = "u-boot";
+			load = <0x0 0x40000000>;
+			entry = <0x0 0x40000000>;
+			compression = "none";
+		};
+	};
+
+	configurations {
+		default = "config-1";
+
+		config-1 {
+			description = "U-boot-spl FIT config for JH7110 VisionFive2";
+			firmware = "firmware";
+		};
+	};
+};

--- a/recipes-bsp/opensbi/opensbi_%.bbappend
+++ b/recipes-bsp/opensbi/opensbi_%.bbappend
@@ -1,2 +1,16 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
 # Support fdt drivers for AE350
 SRCREV:ae350-ax45mp = "22f38ee6c658a660083aa45c4ec6c72f66a17260"
+
+SRC_URI:append:visionfive2 = "\
+	file://visionfive2-uboot-fit-image.its \
+	"
+
+DEPENDS:visionfive2:append = " u-boot-tools-native dtc-native"
+
+do_deploy:append:visionfive2() {
+	install -m 0644 ${WORKDIR}/visionfive2-uboot-fit-image.its ${DEPLOYDIR}/visionfive2-uboot-fit-image.its
+	cd ${DEPLOYDIR}
+	mkimage -f visionfive2-uboot-fit-image.its -A riscv -O u-boot -T firmware visionfive2_fw_payload.img
+}

--- a/recipes-bsp/u-boot/u-boot-starfive/uEnv-visionfive2.txt
+++ b/recipes-bsp/u-boot/u-boot-starfive/uEnv-visionfive2.txt
@@ -1,14 +1,22 @@
-fdt_high=0xffffffffffffffff
-initrd_high=0xffffffffffffffff
-kernel_addr_r=0x44000000
-kernel_comp_addr_r=0x90000000
-kernel_comp_size=0x10000000
-fdt_addr_r=0x48000000
-ramdisk_addr_r=0x48100000
-# Move distro to first boot to speed up booting
-boot_targets=distro mmc0 dhcp
-# Fix wrong fdtfile name
-fdtfile=starfive/jh7110-visionfive-v2.dtb
-# Fix missing bootcmd
-bootcmd=run bootcmd_distro
-bootargs=root=/dev/mmcblk1p2 rw console=tty0 console=ttyS0,115200 earlycon rootwait stmmaceth=chain_mode:1 selinux=0
+# This is the sample jh7110_uEnv.txt file for starfive visionfive U-boot
+# The current convention (SUBJECT TO CHANGE) is that this file
+# will be loaded from the third partition on the
+# MMC card.
+#devnum=1
+partnum=3
+
+# The FIT file to boot from
+fitfile=fitImage
+
+# for debugging boot
+bootargs_ext=if test ${devnum} = 0; then setenv bootargs "earlyprintk console=ttyS0,115200 debug rootwait earlycon=sbi root=/dev/mmcblk0p4"; else setenv bootargs "earlyprintk console=ttyS0,115200 debug rootwait earlycon=sbi root=/dev/mmcblk1p4"; fi;
+
+# for addr info
+fileaddr=0xa0000000
+fdtaddr=0x46000000
+# boot Linux flat or compressed 'Image' stored at 'kernel_addr_r'
+kernel_addr_r=0x40200000
+
+bootwait=setenv _delay ${bootdelay}; echo ${_delay}; while test ${_delay} > 0; do sleep 1; setexpr _delay ${_delay} - 1; echo ${_delay}; done
+
+boot2=run bootargs_ext; mmc dev ${devnum}; fatload mmc ${devnum}:${partnum} ${fileaddr} ${fitfile}; bootm ${fileaddr}

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -1,0 +1,41 @@
+require recipes-bsp/u-boot/u-boot-common.inc
+require recipes-bsp/u-boot/u-boot.inc
+
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+BRANCH:visionfive2 = "JH7110_VisionFive2_devel"
+
+SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;branch=${BRANCH} \
+           file://tftp-mmc-boot.txt \
+          "
+
+SRC_URI:append:visionfive2 = " \
+        file://uEnv-visionfive2.txt \
+"
+
+# tag VF2_v2.11.5
+SRCREV:visionfive2 = "688befadf1d337dee3593e6cc0fe1c737cc150bd"
+
+DEPENDS:append = " u-boot-tools-native"
+
+# Overwrite this for your server
+TFTP_SERVER_IP ?= "127.0.0.1"
+
+do_configure:prepend() {
+    sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${WORKDIR}/tftp-mmc-boot.txt
+    mkimage -O linux -T script -C none -n "U-Boot boot script" \
+        -d ${WORKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
+}
+
+do_deploy:append:visionfive2() {
+    install -m 644 ${WORKDIR}/uEnv-visionfive2.txt ${DEPLOYDIR}/uEnv.txt
+}
+
+COMPATIBLE_MACHINE = "(visionfive2)"
+
+TOOLCHAIN = "gcc"
+
+# U-boot sets O=... which needs it to build outside of S
+B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -20,6 +20,8 @@ SRCREV:visionfive2 = "688befadf1d337dee3593e6cc0fe1c737cc150bd"
 
 DEPENDS:append = " u-boot-tools-native"
 
+DEPENDS:append:visionfive2 = " jh7110-spl-tool-native"
+
 # Overwrite this for your server
 TFTP_SERVER_IP ?= "127.0.0.1"
 
@@ -31,6 +33,9 @@ do_configure:prepend() {
 
 do_deploy:append:visionfive2() {
     install -m 644 ${WORKDIR}/uEnv-visionfive2.txt ${DEPLOYDIR}/uEnv.txt
+    spl_tool -c -f ${DEPLOYDIR}/${SPL_IMAGE}
+    ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_BINARYNAME}.normal.out
+    ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_SYMLINK}.normal.out
 }
 
 COMPATIBLE_MACHINE = "(visionfive2)"

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -32,7 +32,7 @@ do_configure:prepend() {
 }
 
 do_deploy:append:visionfive2() {
-    install -m 644 ${WORKDIR}/uEnv-visionfive2.txt ${DEPLOYDIR}/uEnv.txt
+    install -m 644 ${WORKDIR}/uEnv-visionfive2.txt ${DEPLOYDIR}/vf2_uEnv.txt
     spl_tool -c -f ${DEPLOYDIR}/${SPL_IMAGE}
     ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_BINARYNAME}.normal.out
     ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_SYMLINK}.normal.out

--- a/wic/visionfive2.wks
+++ b/wic/visionfive2.wks
@@ -1,0 +1,22 @@
+# short-description: Create a bootable SD card image for Starfive Visionfive2 board
+# long-description:
+# Create a bootable image that can be written onto a SD card using dd for use
+# with Starfive Visionfive2 board
+# It uses SPL and u-boot
+#
+# The disk layout used is:
+#  - ----- --------- -------------- --------------
+# | | SPL | u-boot  |    boot      |    rootfs    |
+#  - ----- --------- -------------- --------------
+# ^ ^     ^         ^              ^
+# | |     |         |              |
+# 0 2MiB  4MiB   8MiB          300MiB + rootfs + IMAGE_EXTRA_SPACE
+#
+part spl --source rawcopy --sourceparams="file=u-boot-spl.bin.normal.out" --part-name spl --offset 4096S --size 2M --part-type 2E54B353-1271-4842-806F-E436D6AF6985
+
+part uboot --source rawcopy --sourceparams="file=visionfive2_fw_payload.img" --part-name uboot --offset 8192S --size 4M --part-type 5B193300-FC78-40CD-8002-E86C45580B47
+
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label boot --use-uuid --part-name boot --part-type EBD0A0A2-B9E5-4433-87C0-68B6B72699C7 --align 4096 --size 292M
+
+part /root --source rootfs --ondisk mmcblk --fstype=ext4 --part-name boot --part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4 --active --label root --align 4096
+bootloader  --ptable gpt


### PR DESCRIPTION
This PR provides changes to create a bootable Visionfive2 SD card image, similar to the one created in the original Starfive SDK. 
Changes include:
* Add wks file with the partition layout taken from [here](https://github.com/starfive-tech/VisionFive2/blob/JH7110_VisionFive2_devel/conf/genimage-vf2.cfg)
* Add jh7710-spl-tool which is used to generate u-boot-spl.bin.normal.out expected on the SD card by the BootROM
* Deploy visionfive2_fw_payload.img, which is a FIT image containing fw_payload.bin expected by SPL started from SD card
* Update uEnv.txt, so that u-boot-starfive boots fitImage from the partition 3 and rootfs is expected on partition 4 of the SD card 

Current state - SD card flashed with the core-image-minimal-visionfive2.wic using 'dd' or 'bmaptool' boots fine with few issues:
* SPL built with bitbake, reports wrong DRAM size [here](https://github.com/starfive-tech/u-boot/blob/JH7110_VisionFive2_devel/arch/riscv/cpu/jh7110/dram.c#L14). Simply putting a debug message printing in the dram_init() function resolves this issue. Seems like this has something to do with compiler/flags. Investigating.
* During the boot, Linux kernel resets around 4 seconds timestamp. The same behavior is observed with the Starfive SDK [sdcard.img](https://github.com/starfive-tech/VisionFive2/releases/download/VF2_v2.10.4/sdcard.img). Investigating.