### PR TITLE
Fix VisionFive 2 boot and Add Star64 Board

### DIFF
--- a/conf/machine/JH7110.inc
+++ b/conf/machine/JH7110.inc
@@ -1,0 +1,76 @@
+#@TYPE: SOC
+#@NAME: StarFive JH7110
+#@SOC: StarFive JH7110
+#@DESCRIPTION: SOC configuration for the StarFive JH7110
+
+require conf/machine/include/riscv/tune-riscv.inc
+require conf/machine/include/soc-family.inc
+
+MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
+SOC_FAMILY = "jh7110"
+
+UBOOT_ENV ?= "boot"
+UBOOT_ENV_SUFFIX = "scr.uimg"
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-starfive-dev"
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-starfive"
+
+PREFERRED_PROVIDER_virtual/libgl ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/mesa ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/libgbm ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/egl ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/libgles3 ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/libgles2 ?= "visionfive2-pvr-graphics"
+PREFERRED_PROVIDER_virtual/libomxil ?= "libsf-omxil"
+
+PREFERRED_VERSION_openocd-native = "riscv"
+PREFERRED_VERSION_openocd = "riscv"
+
+RISCV_SBI_PLAT = "generic"
+
+## This sets u-boot as the default OpenSBI payload
+RISCV_SBI_PAYLOAD ?= "u-boot.bin"
+
+SERIAL_CONSOLES = "115200;ttyS0"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    kernel-modules \
+    vdec-module \
+    venc-module \
+    jpu-module \
+    linux-firmware-visionfive2-imggpu \
+"
+
+IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
+
+## Do not update fstab file when using wic images
+WIC_CREATE_EXTRA_ARGS ?=  "--no-fstab-update"
+
+EXTRA_IMAGEDEPENDS += "u-boot-starfive"
+
+KERNEL_IMAGETYPE ?= "fitImage"
+KERNEL_CLASSES = "kernel-fitimage"
+UBOOT_ENTRYPOINT = "0x40200000"
+UBOOT_DTB_LOADADDRESS = "0x46000000"
+UBOOT_RD_LOADADDRESS = "0x46100000"
+UBOOT_DTB = "1"
+
+SPL_BINARY = "spl/u-boot-spl.bin"
+SPL_NORMAL_BINARY = "u-boot-spl.bin.normal.out"
+
+## wic default support
+WKS_FILE_DEPENDS ?= " \
+    opensbi \
+    e2fsprogs-native \
+    bmap-tools-native \
+"
+
+IMAGE_BOOT_FILES ?= " \
+    fw_payload.bin \
+    ${KERNEL_IMAGETYPE} \
+    ${RISCV_SBI_FDT}  \
+    boot.scr.uimg \
+    vf2_uEnv.txt \
+"
+
+WKS_FILE ?= "visionfive2.wks"

--- a/conf/machine/star64.conf
+++ b/conf/machine/star64.conf
@@ -1,0 +1,24 @@
+#@TYPE: Machine
+#@NAME: Star64
+#@SOC: StarFive JH7110
+#@DESCRIPTION: Machine configuration for the Star64 board
+
+require conf/machine/JH7110.inc
+
+RISCV_SBI_FDT ?= "pine64_star64.dtb"
+
+KERNEL_DEVICETREE ?= "starfive/jh7110-pine64-star64.dtb"
+
+UBOOT_MACHINE = "pine64_star64_defconfig"
+
+
+UBOOT_DTB_BINARY = "pine64_star64.dtb"
+
+IMAGE_BOOT_FILES = " \
+    ${KERNEL_IMAGETYPE}-${INITRAMFS_IMAGE_NAME}-star64;${KERNEL_IMAGETYPE} \
+    vf2_uEnv.txt \
+"
+
+
+#UBOOT_ENV_SUFFIX:remove = "scr.uimg"
+

--- a/conf/machine/visionfive2.conf
+++ b/conf/machine/visionfive2.conf
@@ -3,60 +3,18 @@
 #@SOC: StarFive JH7110
 #@DESCRIPTION: Machine configuration for the VisionFive 2 board
 
-require conf/machine/include/riscv/tune-riscv.inc
-
-MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
-
-KERNEL_CLASSES = "kernel-fitimage"
-KERNEL_IMAGETYPE = "fitImage"
-UBOOT_ENV ?= "boot"
-UBOOT_ENV_SUFFIX = "scr.uimg"
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-starfive-dev"
-PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-starfive"
-
-PREFERRED_PROVIDER_virtual/libgl ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/mesa ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/libgbm ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/egl ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/libgles3 ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/libgles2 ?= "visionfive2-pvr-graphics"
-PREFERRED_PROVIDER_virtual/libomxil ?= "libsf-omxil"
-
-PREFERRED_VERSION_openocd-native = "riscv"
-PREFERRED_VERSION_openocd = "riscv"
-
-RISCV_SBI_PLAT = "generic"
-
-## This sets u-boot as the default OpenSBI payload
-RISCV_SBI_PAYLOAD ?= "u-boot.bin"
+require conf/machine/JH7110.inc
 
 RISCV_SBI_FDT ?= "jh7110-visionfive-v2.dtb"
 
-SERIAL_CONSOLES = "115200;ttyS0"
-
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    kernel-modules \
-    vdec-module \
-    venc-module \
-    jpu-module \
-"
-
-IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
 KERNEL_DEVICETREE ?= "starfive/jh7110-visionfive-v2.dtb"
 
 ## Do not update fstab file when using wic images
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 
-EXTRA_IMAGEDEPENDS += "u-boot-starfive"
 UBOOT_MACHINE = "starfive_visionfive2_defconfig"
 
-UBOOT_ENTRYPOINT = "0x80200000"
-UBOOT_DTB_LOADADDRESS = "0x82200000"
-UBOOT_DTB = "1"
 UBOOT_DTB_BINARY = "starfive_visionfive2.dtb"
-SPL_BINARY = "spl/u-boot-spl.bin"
-SPL_NORMAL_BINARY = "u-boot-spl.bin.normal.out"
 
 ## wic default support
 WKS_FILE_DEPENDS ?= " \

--- a/recipes-bsp/opensbi/opensbi/visionfive2-uboot-fit-image.its
+++ b/recipes-bsp/opensbi/opensbi/visionfive2-uboot-fit-image.its
@@ -21,7 +21,7 @@
 		default = "config-1";
 
 		config-1 {
-			description = "U-boot-spl FIT config for JH7110 VisionFive2";
+			description = "U-boot-spl FIT config for JH7110 SOC";
 			firmware = "firmware";
 		};
 	};

--- a/recipes-bsp/opensbi/opensbi_%.bbappend
+++ b/recipes-bsp/opensbi/opensbi_%.bbappend
@@ -2,15 +2,18 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 # Support fdt drivers for AE350
 SRCREV:ae350-ax45mp = "22f38ee6c658a660083aa45c4ec6c72f66a17260"
+SRCREV:jh7100 = "568ea49490d935e01b9a41ef8bb5daf9cb0ef201"
 
-SRC_URI:append:visionfive2 = "\
+SRC_URI:append:jh7110 = "\
 	file://visionfive2-uboot-fit-image.its \
 	"
 
-DEPENDS:visionfive2:append = " u-boot-tools-native dtc-native"
+DEPENDS:jh7110:append = " u-boot-tools-native dtc-native"
+EXTRA_OEMAKE:append = " FW_TEXT_START=0x40000000"
 
-do_deploy:append:visionfive2() {
+do_deploy:append:jh7110() {
 	install -m 0644 ${WORKDIR}/visionfive2-uboot-fit-image.its ${DEPLOYDIR}/visionfive2-uboot-fit-image.its
 	cd ${DEPLOYDIR}
 	mkimage -f visionfive2-uboot-fit-image.its -A riscv -O u-boot -T firmware visionfive2_fw_payload.img
 }
+

--- a/recipes-bsp/u-boot/u-boot-starfive/uEnv-star64.txt
+++ b/recipes-bsp/u-boot/u-boot-starfive/uEnv-star64.txt
@@ -1,0 +1,32 @@
+# This is the sample jh7110_uEnv.txt file for starfive visionfive U-boot
+# The current convention (SUBJECT TO CHANGE) is that this file
+# will be loaded from the third partition on the
+# MMC card.
+#devnum=1
+partnum=3
+
+# The FIT file to boot from
+fitfile=fitImage
+
+# for debugging boot
+bootargs_ext=if test ${devnum} = 0; then setenv bootargs "earlyprintk console=tty1 console=ttyS0,115200 rootwait earlycon=sbi root=/dev/mmcblk0p4"; else setenv bootargs "earlyprintk console=tty1 console=ttyS0,115200 rootwait earlycon=sbi root=/dev/mmcblk1p4"; fi;
+#bootargs=earlyprintk console=ttyS0,115200 debug rootwait earlycon=sbi root=/dev/mmcblk1p4
+
+# for addr info
+fileaddr=0xa0000000
+fdtaddr=0x46000000
+# boot Linux flat or compressed 'Image' stored at 'kernel_addr_r'
+kernel_addr_r=0x40200000
+irdaddr=46100000
+irdsize=5f00000
+
+# Use the FDT in the FIT image..
+setupfdt1=fdt addr ${fdtaddr}; fdt resize;
+
+setupird=setexpr irdend ${irdaddr} + ${irdsize}; fdt set /chosen linux,initrd-start <0x0 0x${irdaddr}>; fdt set /chosen linux,initrd-end <0x0 0x${irdend}>
+
+setupfdt2=fdt set /chosen bootargs "${bootargs}";
+
+bootwait=setenv _delay ${bootdelay}; echo ${_delay}; while test ${_delay} > 0; do sleep 1; setexpr _delay ${_delay} - 1; echo ${_delay}; done
+
+boot2=run bootargs_ext; mmc dev ${devnum}; fatload mmc ${devnum}:${partnum} ${fileaddr} ${fitfile}; bootm start ${fileaddr}; run setupfdt1;run setupird;run setupfdt2; bootm loados ${fileaddr}; run chipa_set_linux; run cpu_vol_set; echo "Booting kernel in"; booti ${kernel_addr_r} ${irdaddr}:${filesize} ${fdtaddr}

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -1,13 +1,20 @@
 require recipes-bsp/u-boot/u-boot-common.inc
 require recipes-bsp/u-boot/u-boot.inc
 
+inherit uboot-extlinux-config
+
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 BRANCH:visionfive2 = "JH7110_VisionFive2_devel"
+BRANCH:star64 = "Star64"
 
 SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;branch=${BRANCH} \
+           file://tftp-mmc-boot.txt \
+          "
+
+SRC_URI:star64 = "git://github.com/Fishwaldo/u-boot.git;protocol=https;branch=${BRANCH} \
            file://tftp-mmc-boot.txt \
           "
 
@@ -15,12 +22,19 @@ SRC_URI:append:visionfive2 = " \
         file://uEnv-visionfive2.txt \
 "
 
+SRC_URI:append:star64 = " \
+        file://uEnv-star64.txt \
+"
+
+
 # tag VF2_v2.11.5
 SRCREV:visionfive2 = "688befadf1d337dee3593e6cc0fe1c737cc150bd"
+SRCREV:star64 = "c71fa7376f4eaf29e2dc20e5a68418d79201290a"
+
 
 DEPENDS:append = " u-boot-tools-native"
 
-DEPENDS:append:visionfive2 = " jh7110-spl-tool-native"
+DEPENDS:append:jh7110 = " jh7110-spl-tool-native"
 
 # Overwrite this for your server
 TFTP_SERVER_IP ?= "127.0.0.1"
@@ -31,16 +45,25 @@ do_configure:prepend() {
         -d ${WORKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
 }
 
-do_deploy:append:visionfive2() {
+do_deploy:append:jh7110() {
     install -m 644 ${WORKDIR}/uEnv-visionfive2.txt ${DEPLOYDIR}/vf2_uEnv.txt
     spl_tool -c -f ${DEPLOYDIR}/${SPL_IMAGE}
     ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_BINARYNAME}.normal.out
     ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_SYMLINK}.normal.out
 }
 
-COMPATIBLE_MACHINE = "(visionfive2)"
+do_deploy:append:star64() {
+    install -m 644 ${WORKDIR}/uEnv-star64.txt ${DEPLOYDIR}/vf2_uEnv.txt
+    spl_tool -c -f ${DEPLOYDIR}/${SPL_IMAGE}
+    ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_BINARYNAME}.normal.out
+    ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_SYMLINK}.normal.out
+}
+
+
+COMPATIBLE_MACHINE = "jh7110"
 
 TOOLCHAIN = "gcc"
+
 
 # U-boot sets O=... which needs it to build outside of S
 B = "${WORKDIR}/build"

--- a/recipes-graphics/drivers/visionfive2-pvr-graphics_1.17.bb
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics_1.17.bb
@@ -1,7 +1,7 @@
 LICENSE="CLOSED"
 
 PROVIDES = "virtual/libgles2"
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit update-rc.d

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_%.bbappend
@@ -1,2 +1,2 @@
 # provide visionfive2 specific X11 config
-FILESEXTRAPATHS:prepend:visionfive2 := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend:jh7110 := "${THISDIR}/${PN}:"

--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -1,4 +1,4 @@
-RDEPENDS:${PN}:append:visionfive2 = " \
+RDEPENDS:${PN}:append:jh7110 = " \
     xf86-video-modesetting \
     ${PN}-extension-glx \
     xserver-xf86-config \

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -10,11 +10,19 @@ SRCREV = "${AUTOREV}"
 # pin srcrev for now to have a fixed target
 # release VF2_v2.11.5
 SRCREV:visionfive2 = "a87c6861c6d96621026ee53b94f081a1a00a4cc7"
+SRCREV:star64 = "e4c0928f1e42ed82ab9fa8918bc7094d3c0414d8"
 
 BRANCH = "visionfive"
 BRANCH:visionfive2 = "JH7110_VisionFive2_devel"
+BRANCH:star64 = "Star64_devel"
+
 FORK ?= "starfive-tech"
-SRC_URI = "git://github.com/${FORK}/linux.git;protocol=https;branch=${BRANCH} \
+FORK:star64 ?= "Fishwaldo"
+
+REPO ?= "linux"
+REPO:star64 ?= "Star64_linux"
+
+SRC_URI = "git://github.com/${FORK}/${REPO}.git;protocol=https;branch=${BRANCH} \
            file://modules.cfg \
           "
 SRC_URI:append:beaglev-starlight-jh7100 = " \
@@ -24,16 +32,18 @@ SRC_URI:append:visionfive = " \
            file://extra.cfg \
 "
 
-SRC_URI:append:visionfive2 = " \
+SRC_URI:append:jh7110 = " \
            file://visionfive2-graphics.cfg \
 "
 
 LINUX_VERSION ?= "6.2.0"
-LINUX_VERSION:visionfive2 = "5.15.0"
+LINUX_VERSION:jh7110 = "5.15.0"
 LINUX_VERSION_EXTENSION:append:beaglev-starlight-jh7100 = "-starlight"
 
 KBUILD_DEFCONFIG:beaglev-starlight-jh7100 = "starfive_jh7100_fedora_defconfig"
 KBUILD_DEFCONFIG:visionfive = "visionfive_defconfig"
 KBUILD_DEFCONFIG:visionfive2 = "starfive_visionfive2_defconfig"
+KBUILD_DEFCONFIG:star64 = "pine64_star64_defconfig"
 
-COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100|visionfive|visionfive2)"
+
+COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100|visionfive|jh7110)"

--- a/recipes-kernel/modules/jpu-module.bb
+++ b/recipes-kernel/modules/jpu-module.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "CODAJ12 performs JPEG encoding/decoding and is a chipset from Chi
 LICENSE = "ChipsMedia_VisionFive2"
 LIC_FILES_CHKSUM = "file://../../../LICENSE.txt;md5=16bead7cc56b053f5da0061ce0637ad2"
 
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 JPU_MODULE_SRC = "git/codaj12/jdi/linux/driver"
 

--- a/recipes-kernel/modules/vdec-module.bb
+++ b/recipes-kernel/modules/vdec-module.bb
@@ -5,7 +5,7 @@ formats which provide high-performance decode capability. WAVE511 was also calle
 LICENSE = "ChipsMedia_VisionFive2"
 LIC_FILES_CHKSUM = "file://../../../LICENSE.txt;md5=16bead7cc56b053f5da0061ce0637ad2"
 
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 WAVE511_MODULE_SRC = "git/wave511/code/vdi/linux/driver"
 

--- a/recipes-kernel/modules/venc-module.bb
+++ b/recipes-kernel/modules/venc-module.bb
@@ -5,7 +5,7 @@ encoding FHD/UHD HEVC/H.265 main profile L4.1. WAVE420L was also call *VPU Enc*"
 LICENSE = "ChipsMedia_VisionFive2"
 LIC_FILES_CHKSUM = "file://../../../LICENSE.txt;md5=16bead7cc56b053f5da0061ce0637ad2"
 
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 WAVE420L_MODULE_SRC = "git/wave420l/code/vdi/linux/driver"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI:append:visionfive2 = "\
+SRC_URI:append:jh7110 = "\
     file://0001-add-starfive-support.patch \
     file://0002-Fix-gst-omx-Enable-the-gst-omx-VPU-decoding-and-enco.patch \
     file://0003-add-video-scale-support.patch \
@@ -21,7 +21,7 @@ SRC_URI:append:visionfive2 = "\
     file://0018-support-cut-for-gstomxmjpegdec.patch \
     file://0019-Add-Interlaced-mode-judgment.patch \
 "
-GSTREAMER_1_0_OMX_TARGET:visionfive2 = "stf"
-GSTREAMER_1_0_OMX_CORE_NAME:visionfive2 = "${libdir}/libsf-omx-il.so"
-EXTRA_OEMESON:append:visionfive2 = " -Dheader_path=${STAGING_DIR_TARGET}/usr/include/khronos"
-VIRTUAL-RUNTIME_libomxil:visionfive2 = "libsf-omxil"
+GSTREAMER_1_0_OMX_TARGET:jh7110 = "stf"
+GSTREAMER_1_0_OMX_CORE_NAME:jh7110 = "${libdir}/libsf-omx-il.so"
+EXTRA_OEMESON:append:jh7110 = " -Dheader_path=${STAGING_DIR_TARGET}/usr/include/khronos"
+VIRTUAL-RUNTIME_libomxil:jh7110 = "libsf-omxil"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG:append:visionfive2 = " kms"
+PACKAGECONFIG:append:jh7110 = " kms"

--- a/recipes-multimedia/vpu/libsf-codaj12.bb
+++ b/recipes-multimedia/vpu/libsf-codaj12.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "CODAJ12 performs the JPEG baseline/extended sequential and M-JPEG
 LICENSE = "ChipsMedia_VisionFive2"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=16bead7cc56b053f5da0061ce0637ad2"
 
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit autotools

--- a/recipes-multimedia/vpu/libsf-omxil.bb
+++ b/recipes-multimedia/vpu/libsf-omxil.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Library provides OpenMAX API for VPU access via WAVE420l, WAVE511
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
 
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 PROVIDES = "virtual/libomxil"
 

--- a/recipes-multimedia/vpu/libsf-wave420l.bb
+++ b/recipes-multimedia/vpu/libsf-wave420l.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Library provides API to venc Kernel module for using the WAVE420l
 LICENSE = "ChipsMedia_VisionFive2"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=16bead7cc56b053f5da0061ce0637ad2"
 
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit autotools

--- a/recipes-multimedia/vpu/libsf-wave511.bb
+++ b/recipes-multimedia/vpu/libsf-wave511.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "Library provides API to vdec Kernel module for using the WAVE511 
 LICENSE = "ChipsMedia_VisionFive2"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=16bead7cc56b053f5da0061ce0637ad2"
 
-COMPATIBLE_MACHINE = "visionfive2"
+COMPATIBLE_MACHINE = "jh7110"
 
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit autotools


### PR DESCRIPTION
Several issues with the current visionfive 2 support:
* JH7110 Support is only in OpenSBI Master branch, (upcoming 1.3 release).  So pin OpenSBI Revision to the commit that adds JH7110 Support otherwise reset etc does not work
* There are two variants of VisionFive2 and Star64 - 4Gb and 8Gb. StarFive's u-boot reads the eeprom on board to determine what variant you have, and modifies the loaded FDT it passes to the kernel with the correct Memory. Current U-boot scripts in meta-riscv do not do this, and thus all boards end up with the default 4Gb configuration. I've updated this for Star64, but needs testing on VF2

* Some of the addresses used in uboot for kernel/initramfs or fdt were different from upstream. Aligned the addresses with upstream StarFive.

As both Star64 and VisionFive2 are based on the same SOC, i've changed the machine configuration so we have a JH7110 SOC and VisionFive2 and Star64 inherit from this. Where appropriate in the recipies, I've changed to jh7110 instead of visionfive2

Finally, as the Star64 has different kernel/u-boot configs/dts files, i've pointed those at my repos for now, and will be up streaming (assuming Starfive accept star64 related PRs). Once up-streamed, I'll submit a new PR here.

This also lays the groundwork for the new PineTab-V from pine64 which is due to be shipped in May.

**-Signed-off-by: Justin Hammond <justin@dynam.ac> **

