### PR TITLE
opensbi: Make FW_TEXT_START=0x40000000 specific to jh7110

### DIFF
--- a/recipes-bsp/opensbi/opensbi_%.bbappend
+++ b/recipes-bsp/opensbi/opensbi_%.bbappend
@@ -8,12 +8,11 @@ SRC_URI:append:jh7110 = "\
 	file://visionfive2-uboot-fit-image.its \
 	"
 
-DEPENDS:jh7110:append = " u-boot-tools-native dtc-native"
-EXTRA_OEMAKE:append = " FW_TEXT_START=0x40000000"
+DEPENDS:append:jh7110 = " u-boot-tools-native dtc-native"
+EXTRA_OEMAKE:jh7110:append = " FW_TEXT_START=0x40000000"
 
 do_deploy:append:jh7110() {
 	install -m 0644 ${WORKDIR}/visionfive2-uboot-fit-image.its ${DEPLOYDIR}/visionfive2-uboot-fit-image.its
 	cd ${DEPLOYDIR}
 	mkimage -f visionfive2-uboot-fit-image.its -A riscv -O u-boot -T firmware visionfive2_fw_payload.img
 }
-


### PR DESCRIPTION
This ensures that it does not inflict upon other RISCV SOCs and qemu based machines, which can result in non-booting systems since entry adddress in FW_JUMP Firmware Configuration  is wrong.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

