### PR TITLE
visionfive2: Do not package vulkan prebuilts

### DIFF
--- a/recipes-graphics/drivers/visionfive2-pvr-graphics_1.17.bb
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics_1.17.bb
@@ -25,7 +25,8 @@ do_install () {
     cp -r ${D}/${IMG_GPU_POWERVR_VERSION}/staging/usr/include/GLES3/ ${D}/usr/include/
     install -d ${D}/usr/lib/pkgconfig/
     cp -r ${D}/${IMG_GPU_POWERVR_VERSION}/staging/usr/lib/pkgconfig/* ${D}/usr/lib/pkgconfig/
-
+    # let vulkan-loader from core layer provide libvulkan
+    rm -rf ${D}${libdir}/libvulkan*.so* ${D}${libdir}/pkgconfig/vulkan.pc
     # provided via separate arch-independent firmware package
     rm -rf ${D}/lib/firmware
     rmdir ${D}/lib

--- a/recipes-multimedia/vpu/libsf-codaj12/codaj12_yocto.mak
+++ b/recipes-multimedia/vpu/libsf-codaj12/codaj12_yocto.mak
@@ -126,7 +126,7 @@ ifeq ($(USE_RTL_SIM), yes)
 DECTEST: CREATE_DIR $(OBJECTPATHS_COMMON)
 else
 DECTEST: CREATE_DIR $(OBJECTPATHS_COMMON)
-	$(LINKER) -g -fPIC -shared -o $(DECTEST) $(LDFLAGS) -Wl,-gc-section -Wl,--start-group $(OBJECTPATHS_COMMON) $(LDLIBS) -Wl,--end-group
+	$(LINKER) -g -fPIC -shared -o $(DECTEST) $(LDFLAGS) -Wl,-gc-sections -Wl,--start-group $(OBJECTPATHS_COMMON) $(LDLIBS) -Wl,--end-group
 endif
 
 

--- a/recipes-multimedia/vpu/libsf-wave420l/WaveEncoder_yocto.mak
+++ b/recipes-multimedia/vpu/libsf-wave420l/WaveEncoder_yocto.mak
@@ -131,7 +131,7 @@ OBJECTNAMES=$(patsubst %.c,%.o,$(patsubst %.cpp,%.o,$(SOURCES)))
 OBJECTPATHS=$(addprefix $(OBJDIR)/,$(notdir $(OBJECTNAMES)))
 
 $(TARGET): create_dir $(OBJECTPATHS) #libtheoraparser.a
-	$(LINKING) -fPIC -shared -o $@ $(LDFLAGS) -Wl,-gc-section -Wl,--start-group $(OBJECTPATHS) $(LDLIBS) -Wl,--end-group
+	$(LINKING) -fPIC -shared -o $@ $(LDFLAGS) -Wl,-gc-sections -Wl,--start-group $(OBJECTPATHS) $(LDLIBS) -Wl,--end-group
 
 -include $(OBJECTPATHS:.o=.dep)
 

--- a/recipes-multimedia/vpu/libsf-wave511/WaveDecode_yocto.mak
+++ b/recipes-multimedia/vpu/libsf-wave511/WaveDecode_yocto.mak
@@ -146,7 +146,7 @@ ifeq ($(USE_RTL_SIM), yes)
 DECTEST: CREATE_DIR $(OBJECTPATHS_COMMON)
 else
 DECTEST: CREATE_DIR $(OBJECTPATHS_COMMON)
-	$(LINKER) -fPIC -shared -o $(DECTEST) $(LDFLAGS) -Wl,-gc-section -Wl,--start-group $(OBJECTPATHS_COMMON) $(LDLIBS) -Wl,--end-group
+	$(LINKER) -fPIC -shared -o $(DECTEST) $(LDFLAGS) -Wl,-gc-sections -Wl,--start-group $(OBJECTPATHS_COMMON) $(LDLIBS) -Wl,--end-group
 endif
 
 -include $(OBJECTPATHS:.o=.dep)


### PR DESCRIPTION
This helps in avoiding conflicts with oe-core provided vulkan-loader recipe

ERROR: The file /usr/lib/libvulkan.so.1 is installed by both visionfive2-pvr-graphics and vulkan-loader, aborting

