### PR TITLE
Update VisionFive2 SDK to 3.0.4

### DIFF
--- a/conf/machine/JH7110.inc
+++ b/conf/machine/JH7110.inc
@@ -35,11 +35,13 @@ SERIAL_CONSOLES = "115200;ttyS0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
+    linux-firmware-visionfive2-imggpu \
     vdec-module \
     venc-module \
     jpu-module \
-    linux-firmware-visionfive2-imggpu \
 "
+
+KERNEL_MODULE_AUTOLOAD += "pvrsrvkm"
 
 IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
 

--- a/recipes-bsp/common/visionfive2-firmware.inc
+++ b/recipes-bsp/common/visionfive2-firmware.inc
@@ -1,6 +1,6 @@
-VISIONFIVE2FW_DATE ?= "20230320"
-# VF2_v2.11.5
-SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=cd7b50cd9f9eca66c23ebd19f06a172ce0be591f"
+VISIONFIVE2FW_DATE ?= "20230524"
+# VF2_v3.0.4
+SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=a8d360763d203874fefe38fad2b041b98d674743"
 HOMEPAGE ?= "https://github.com/starfive-tech/soft_3rdpart"
 
 PV ?= "${VISIONFIVE2FW_DATE}"

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -8,8 +8,8 @@ KERNEL_VERSION_SANITY_SKIP = "1"
 SRCREV = "${AUTOREV}"
 
 # pin srcrev for now to have a fixed target
-# release VF2_v2.11.5
-SRCREV:visionfive2 = "a87c6861c6d96621026ee53b94f081a1a00a4cc7"
+# release VF2_v3.0.4
+SRCREV:visionfive2 = "d9eee31aaec51ade1641391836c1f07dd2151a4a"
 SRCREV:star64 = "e4c0928f1e42ed82ab9fa8918bc7094d3c0414d8"
 
 BRANCH = "visionfive"
@@ -34,6 +34,7 @@ SRC_URI:append:visionfive = " \
 
 SRC_URI:append:jh7110 = " \
            file://visionfive2-graphics.cfg \
+           file://0001-Allow-building-of-PVR-GPU-driver-as-module.patch \
 "
 
 LINUX_VERSION ?= "6.2.0"

--- a/recipes-kernel/linux/linux-starfive/0001-Allow-building-of-PVR-GPU-driver-as-module.patch
+++ b/recipes-kernel/linux/linux-starfive/0001-Allow-building-of-PVR-GPU-driver-as-module.patch
@@ -1,0 +1,23 @@
+From f27fa21b1536cf29a5ce829a57e92d4c70e88f8c Mon Sep 17 00:00:00 2001
+From: Andreas Cord-Landwehr <cordlandwehr@kde.org>
+Date: Sat, 17 Jun 2023 09:15:48 +0200
+Subject: [PATCH] Allow building of PVR GPU driver as module
+
+---
+ drivers/gpu/drm/img/img-rogue/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/img/img-rogue/Kconfig b/drivers/gpu/drm/img/img-rogue/Kconfig
+index 5b793bb9da0e..6f84a2643e02 100644
+--- a/drivers/gpu/drm/img/img-rogue/Kconfig
++++ b/drivers/gpu/drm/img/img-rogue/Kconfig
+@@ -1,5 +1,5 @@
+ config DRM_IMG_ROGUE
+-	bool "DRM support for PowerVR GPU"
++	tristate "DRM support for PowerVR GPU"
+ 	select DRM_IMG
+ 	default n
+ 	help
+-- 
+2.39.2
+

--- a/recipes-kernel/linux/linux-starfive/visionfive2-graphics.cfg
+++ b/recipes-kernel/linux/linux-starfive/visionfive2-graphics.cfg
@@ -1,1 +1,8 @@
 CONFIG_CMA_SIZE_MBYTES=256
+
+# workaround: build as module to postpone loading until binary blobs are available in rootfs
+CONFIG_DRM=y
+CONFIG_DRM_IMG_ROGUE=m
+
+# commented out because fails to build with DRM_IMG_ROGUE being a module
+CONFIG_VIN_SENSOR_IMX219=n


### PR DESCRIPTION
This small update introduces two main changes:

- update binary blobs and VF2 specific libs to latest SDK (eg. fixes video acceleration, fixes red taint of display output)
- modifies GPU driver to be built as module, which fixes/workarounds a common race condition on Kernel loading when GPU binary blobs are not there then driver is initialized