### PR TITLE
visionfive2-pvr-graphics: Package for musl

### DIFF
--- a/recipes-graphics/drivers/visionfive2-pvr-graphics/rc.pvr.service
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics/rc.pvr.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=PowerVR consumer services
+
+[Service]
+ExecStart=/usr/bin/rc.pvr start
+ExecStop=/usr/bin/rc.pvr stop
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
@@ -6,6 +6,8 @@ COMPATIBLE_MACHINE = "jh7110"
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit update-rc.d
 
+DEPENDS:append:libc-musl = " gcompat"
+
 SRC_URI += "\
         file://glesv1_cm.pc \
 "
@@ -68,3 +70,6 @@ INSANE_SKIP:${PN} += "already-stripped dev-so"
 # ignore dependency check for python scripting
 INSANE_SKIP:${PN}-tools += "already-stripped file-rdeps"
 INSANE_SKIP:${PN}-firmware += "arch"
+# It will use gcompat at runtime therefore checking for these at compile time wont be useful as
+# they dont match musl/gcompat but it should run fine
+INSANE_SKIP:append:libc-musl = " file-rdeps"


### PR DESCRIPTION
This can be used via gcompat coupling at runtime to provide glibc API calls translation to musl.

