### PR TITLE
Update VisionFive2 Firmware to Release v3.4.5

### DIFF
--- a/recipes-bsp/common/visionfive2-firmware.inc
+++ b/recipes-bsp/common/visionfive2-firmware.inc
@@ -1,6 +1,6 @@
-VISIONFIVE2FW_DATE ?= "20230621"
-# VF2_v3.1.5
-SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=e2b76cd5733ce85d7145a6d71fb50a6218abed5c"
+VISIONFIVE2FW_DATE ?= "20230808"
+# VF2_v3.4.5
+SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=12dba467921f5c8154b2afb47eb946eb3b0353a2"
 HOMEPAGE ?= "https://github.com/starfive-tech/soft_3rdpart"
 
 IMG_GPU_POWERVR_VERSION = "img-gpu-powervr-bin-1.19.6345021"

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -8,8 +8,8 @@ KERNEL_VERSION_SANITY_SKIP = "1"
 SRCREV = "${AUTOREV}"
 
 # pin srcrev for now to have a fixed target
-# release VF2_v3.1.5
-SRCREV:visionfive2 = "4964ce0a869e92df26331833894c9d0fd84d80f3"
+# release VF2_v3.4.5
+SRCREV:visionfive2 = "8fe323292f2caf46bde0e0aab8f484f920f521be"
 SRCREV:star64 = "e4c0928f1e42ed82ab9fa8918bc7094d3c0414d8"
 
 BRANCH = "visionfive"


### PR DESCRIPTION
Update for https://github.com/starfive-tech/VisionFive2/releases/tag/VF2_v3.4.5