### PR TITLE
Fix directory not empty error when systemd folder present

### DIFF
--- a/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
@@ -36,12 +36,17 @@ do_install () {
         mv ${D}${sysconfdir}/init.d/rc.pvr ${D}${bindir}
         rmdir ${D}${sysconfdir}/init.d
         install -Dm 644 ${WORKDIR}/rc.pvr.service ${D}/${systemd_unitdir}/system/rc.pvr.service
+    else
+        rm -rf ${D}/lib/systemd
     fi
     # let vulkan-loader from core layer provide libvulkan
     rm -rf ${D}${libdir}/libvulkan*.so* ${D}${libdir}/pkgconfig/vulkan.pc
     # provided via separate arch-independent firmware package
     rm -rf ${D}/lib/firmware
-    rmdir ${D}/lib
+    # Check directory empty before trying to delete
+    if [ -z "$(ls -A ${D}/lib)" ]; then
+        rmdir ${D}/lib
+    fi
 
     # cleanup unused
     rm -rf ${D}/${IMG_GPU_POWERVR_VERSION}


### PR DESCRIPTION
As previously [discussed](https://github.com/riscv/meta-riscv/pull/429)

**- visionfive2-pvr-graphics: Fix 'directory not empty' error when systemd folder present**
  
**-[Affected recipe](https://github.com/riscv/meta-riscv/blob/master/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb)**
  
**-Fix break in build**

**-Signed-off-by: Owen O'Hehir <oo.hehir@gmail.com>**

