### PR TITLE
weston: Ignore undefined symbols in .so on musl/visionfive2

### DIFF
--- a/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
@@ -8,7 +8,7 @@ inherit update-rc.d systemd
 
 SRC_URI += "file://rc.pvr.service"
 
-DEPENDS:append:libc-musl = " gcompat"
+DEPENDS:append:libc-musl = " gcompat patchelf-native"
 
 SRC_URI += "\
         file://glesv1_cm.pc \
@@ -50,6 +50,14 @@ do_install () {
 
     # cleanup unused
     rm -rf ${D}/${IMG_GPU_POWERVR_VERSION}
+}
+
+do_install:append:libc-musl() {
+    # libs
+    for f in `find ${D}${libdir} -name '*.so*' -type f`
+    do
+        patchelf --add-needed libgcompat.so.0 $f
+    done
 }
 
 INITSCRIPT_NAME = "rc.pvr"

--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -3,3 +3,4 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append:jh7110 = " \
     file://0006-libweston-reduce-checks-for-dmabufs-with-DRM-modifie.patch \
 "
+LDFLAGS:append:jh7110:libc-musl = " -Wl,--allow-shlib-undefined"


### PR DESCRIPTION
When using visionfive2 we are using prebuilt blobs for Graphics libraries implementations for GLES1/GLES2 etc. These prebuilts are sadly only build against glibc and have undefined symbols which only glibc knowns about especially versioned ones. We have gcompat library which tries to provide a glue layer for that over musl at runtime, so lets turn a blind eye for link time reports about undefined symbols when building for musl.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

