### PR TITLE
musl: Sync patches with latest musl tip

### DIFF
--- a/recipes-core/musl/musl/0001-Emulate-wait4-using-waitid.patch
+++ b/recipes-core/musl/musl/0001-Emulate-wait4-using-waitid.patch
@@ -1,7 +1,7 @@
-From 1a8f65f2b8d33dc09f6ccb6a7bd6ca85760cf720 Mon Sep 17 00:00:00 2001
+From c3941d7f5a1dba3a10f1d232a81841b4640462c4 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:20:45 -0400
-Subject: [PATCH 07/16] Emulate wait4 using waitid
+Subject: [PATCH 01/12] Emulate wait4 using waitid
 
 riscv32 and future architectures lack wait4.
 
@@ -92,7 +92,7 @@ index 00000000..04d7dc64
 +}
 +#endif
 diff --git a/src/internal/syscall.h b/src/internal/syscall.h
-index 4f41e1dc..27642938 100644
+index 4a446157..28315a1f 100644
 --- a/src/internal/syscall.h
 +++ b/src/internal/syscall.h
 @@ -5,6 +5,8 @@
@@ -120,7 +120,7 @@ index 4f41e1dc..27642938 100644
 +
  #endif
 diff --git a/src/linux/wait4.c b/src/linux/wait4.c
-index 83650e34..32652dc2 100644
+index ff2e3e66..43428153 100644
 --- a/src/linux/wait4.c
 +++ b/src/linux/wait4.c
 @@ -26,7 +26,7 @@ pid_t wait4(pid_t pid, int *status, int options, struct rusage *ru)
@@ -182,5 +182,5 @@ index 557503eb..8e8689c1 100644
  	__restore_sigs(&set);
  
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0002-riscv-Fall-back-to-syscall-__riscv_flush_icache.patch
+++ b/recipes-core/musl/musl/0002-riscv-Fall-back-to-syscall-__riscv_flush_icache.patch
@@ -1,7 +1,7 @@
-From d7bc65df3f6f3026da2094143342e58cd6bdd321 Mon Sep 17 00:00:00 2001
+From fb635e49bdc9f619f369c55ddc27f2b78a68d686 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:23:40 -0400
-Subject: [PATCH 08/16] riscv: Fall back to syscall __riscv_flush_icache
+Subject: [PATCH 02/12] riscv: Fall back to syscall __riscv_flush_icache
 
 Matches glibc behavior and fixes a case where we could fall off the
 function without returning a value.
@@ -24,5 +24,5 @@ index 0eb051c2..9cacac2b 100644
  weak_alias(__riscv_flush_icache, riscv_flush_icache);
  #endif
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0003-riscv32-Target-and-subtarget-detection.patch
+++ b/recipes-core/musl/musl/0003-riscv32-Target-and-subtarget-detection.patch
@@ -1,7 +1,7 @@
-From 798f6231faa7f684962b6ff72d22aa9e268840ed Mon Sep 17 00:00:00 2001
+From 69832b58df5af38a1c65f8466be87ccc88b2040c Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:26:50 -0400
-Subject: [PATCH 09/16] riscv32: Target and subtarget detection
+Subject: [PATCH 03/12] riscv32: Target and subtarget detection
 
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
@@ -10,7 +10,7 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index acbfa8f2..2e217c7e 100755
+index 6b9d70bd..3343d0cf 100755
 --- a/configure
 +++ b/configure
 @@ -336,6 +336,7 @@ or1k*) ARCH=or1k ;;
@@ -21,7 +21,7 @@ index acbfa8f2..2e217c7e 100755
  sh[1-9bel-]*|sh|superh*) ARCH=sh ;;
  s390x*) ARCH=s390x ;;
  unknown) fail "$0: unable to detect target arch; try $0 --target=..." ;;
-@@ -696,7 +697,7 @@ trycppif __LITTLE_ENDIAN__ "$t" && SUBARCH=${SUBARCH}le
+@@ -713,7 +714,7 @@ trycppif __LITTLE_ENDIAN__ "$t" && SUBARCH=${SUBARCH}le
  trycppif _SOFT_FLOAT "$t" && fail "$0: error: soft-float not supported on powerpc64"
  fi
  
@@ -31,5 +31,5 @@ index acbfa8f2..2e217c7e 100755
  trycppif __riscv_float_abi_single "$t" && SUBARCH=${SUBARCH}-sp
  fi
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0004-riscv32-add-arch-headers.patch
+++ b/recipes-core/musl/musl/0004-riscv32-add-arch-headers.patch
@@ -1,7 +1,7 @@
-From bf15d3589b0bc2bcbe9bf1c49bc993ca77e20951 Mon Sep 17 00:00:00 2001
+From 5d89b87310502c9226a7c23bbb5da7f02cf3b852 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:40:29 -0400
-Subject: [PATCH 10/16] riscv32: add arch headers
+Subject: [PATCH 04/12] riscv32: add arch headers
 
 These are mostly copied from riscv64.  _Addr and _Reg had to become int
 to avoid errors in libstdc++ when size_t and std::size_t mismatch.
@@ -16,6 +16,7 @@ names depending on __BITS_PER_LONG, notably mmap2 and _llseek.
 
 futex was added as an alias to futex_time64 since it is widely used by
 software which does not pass time arguments.
+
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
@@ -847,5 +848,5 @@ index 00000000..9e916c76
 +#define VDSO_CGT_SYM "__vdso_clock_gettime"
 +#define VDSO_CGT_VER "LINUX_2.6" */
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0005-riscv32-Add-fenv-and-math.patch
+++ b/recipes-core/musl/musl/0005-riscv32-Add-fenv-and-math.patch
@@ -1,9 +1,10 @@
-From 748bf9c7b74ee056d4d4346f49ea6f824d845f08 Mon Sep 17 00:00:00 2001
+From c650e636442b086b7ab62f3785b5f439085138cb Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:45:44 -0400
-Subject: [PATCH 11/16] riscv32: Add fenv and math
+Subject: [PATCH 05/12] riscv32: Add fenv and math
 
 These are identical to riscv64.
+
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
@@ -361,5 +362,5 @@ index 00000000..610c2cf8
 +
 +#endif
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0006-riscv32-Add-dlsym.patch
+++ b/recipes-core/musl/musl/0006-riscv32-Add-dlsym.patch
@@ -1,9 +1,10 @@
-From 0bb97d2cf32b62aa276414c68b90d6fa319cf16c Mon Sep 17 00:00:00 2001
+From 1c641b69c06aefa950c2dbc8d6efe85227af3d4b Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:46:33 -0400
-Subject: [PATCH 12/16] riscv32: Add dlsym
+Subject: [PATCH 06/12] riscv32: Add dlsym
 
 Identical to riscv64.
+
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
@@ -24,5 +25,5 @@ index 00000000..2bafd72d
 +	mv a2, ra
 +	tail __dlsym
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0007-riscv32-Add-jmp_buf-and-sigreturn.patch
+++ b/recipes-core/musl/musl/0007-riscv32-Add-jmp_buf-and-sigreturn.patch
@@ -1,9 +1,10 @@
-From 0b4555370e3b615453ce002a375809870fe8d8ed Mon Sep 17 00:00:00 2001
+From 288dd5ce780eca2cf368a6e9a390c25ce9ba7e66 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:54:44 -0400
-Subject: [PATCH 13/16] riscv32: Add jmp_buf and sigreturn
+Subject: [PATCH 07/12] riscv32: Add jmp_buf and sigreturn
 
 Largely copied from riscv64 but required recalculation of offsets.
+
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
@@ -156,5 +157,5 @@ index 00000000..c1caeab1
 +.hidden __sigsetjmp_tail
 +	tail __sigsetjmp_tail
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0008-riscv32-Add-thread-support.patch
+++ b/recipes-core/musl/musl/0008-riscv32-Add-thread-support.patch
@@ -1,9 +1,10 @@
-From 09cfd9ee37e253d5ec1afc7ff7df652529e766c6 Mon Sep 17 00:00:00 2001
+From 84783ce0b52da9998d76d2ac0d065ea1229a8b06 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Thu, 3 Sep 2020 05:56:46 -0400
-Subject: [PATCH 14/16] riscv32: Add thread support
+Subject: [PATCH 08/12] riscv32: Add thread support
 
 Identical to riscv64 except for stack offsets in clone.
+
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
@@ -118,5 +119,5 @@ index 00000000..079d1ba0
 +__cp_cancel:
 +	tail __cancel
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl/0009-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch
+++ b/recipes-core/musl/musl/0009-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch
@@ -1,7 +1,7 @@
-From fb2d200423299843818884801e2598dd643ec834 Mon Sep 17 00:00:00 2001
+From 9e8cfaa2aeb9239253f583d53e82bd2993081240 Mon Sep 17 00:00:00 2001
 From: Stefan O'Rear <sorear@fastmail.com>
 Date: Wed, 9 Sep 2020 11:57:54 -0700
-Subject: [PATCH 15/16] Change definitions of F_GETLK, F_SETLK, F_SETLKW
+Subject: [PATCH 09/12] Change definitions of F_GETLK, F_SETLK, F_SETLKW
 
 * gdb HEAD wants ELF_NFPREG, so I set it in bits/user.h to the value
   gdb needs.  (glibc does #define ELF_NFPREG NFPREG and expects gdb
@@ -21,8 +21,8 @@ Subject: [PATCH 15/16] Change definitions of F_GETLK, F_SETLK, F_SETLKW
   the right one.
 
 Upstream-Status: Pending
-Signed-off-by: Stefan O'Rear <sorear@fastmail.com>
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Stefan O'Rear <sorear@fastmail.com>
 ---
  arch/riscv32/bits/fcntl.h   |  7 ++++---
  arch/riscv32/bits/ipcstat.h |  1 +
@@ -31,14 +31,15 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  arch/riscv32/bits/shm.h     | 31 +++++++++++++++++++++++++++++++
  arch/riscv32/bits/user.h    |  1 +
  arch/riscv32/syscall_arch.h |  2 ++
- arch/riscv64/bits/user.h    |  1 +
  src/process/waitpid.c       |  2 +-
- 9 files changed, 77 insertions(+), 4 deletions(-)
+ 8 files changed, 76 insertions(+), 4 deletions(-)
  create mode 100644 arch/riscv32/bits/ipcstat.h
  create mode 100644 arch/riscv32/bits/msg.h
  create mode 100644 arch/riscv32/bits/sem.h
  create mode 100644 arch/riscv32/bits/shm.h
 
+diff --git a/arch/riscv32/bits/fcntl.h b/arch/riscv32/bits/fcntl.h
+index ecb4d18f..66f84fac 100644
 --- a/arch/riscv32/bits/fcntl.h
 +++ b/arch/riscv32/bits/fcntl.h
 @@ -24,14 +24,15 @@
@@ -60,10 +61,16 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  #define F_SETOWN_EX 15
  #define F_GETOWN_EX 16
  
+diff --git a/arch/riscv32/bits/ipcstat.h b/arch/riscv32/bits/ipcstat.h
+new file mode 100644
+index 00000000..4f4fcb0c
 --- /dev/null
 +++ b/arch/riscv32/bits/ipcstat.h
 @@ -0,0 +1 @@
 +#define IPC_STAT 0x102
+diff --git a/arch/riscv32/bits/msg.h b/arch/riscv32/bits/msg.h
+new file mode 100644
+index 00000000..7bbbb2bf
 --- /dev/null
 +++ b/arch/riscv32/bits/msg.h
 @@ -0,0 +1,18 @@
@@ -85,6 +92,9 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 +	time_t msg_rtime;
 +	time_t msg_ctime;
 +};
+diff --git a/arch/riscv32/bits/sem.h b/arch/riscv32/bits/sem.h
+new file mode 100644
+index 00000000..544e3d2a
 --- /dev/null
 +++ b/arch/riscv32/bits/sem.h
 @@ -0,0 +1,18 @@
@@ -106,6 +116,9 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 +	time_t sem_otime;
 +	time_t sem_ctime;
 +};
+diff --git a/arch/riscv32/bits/shm.h b/arch/riscv32/bits/shm.h
+new file mode 100644
+index 00000000..725fb469
 --- /dev/null
 +++ b/arch/riscv32/bits/shm.h
 @@ -0,0 +1,31 @@
@@ -140,6 +153,8 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 +	unsigned long shm_tot, shm_rss, shm_swp;
 +	unsigned long __swap_attempts, __swap_successes;
 +};
+diff --git a/arch/riscv32/bits/user.h b/arch/riscv32/bits/user.h
+index 2da743ea..0d37de0b 100644
 --- a/arch/riscv32/bits/user.h
 +++ b/arch/riscv32/bits/user.h
 @@ -1,5 +1,6 @@
@@ -149,14 +164,18 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 +#define ELF_NFPREG 33
  typedef unsigned long elf_greg_t, elf_gregset_t[ELF_NGREG];
  typedef union __riscv_mc_fp_state elf_fpregset_t;
+diff --git a/arch/riscv32/syscall_arch.h b/arch/riscv32/syscall_arch.h
+index 9e916c76..c507f15f 100644
 --- a/arch/riscv32/syscall_arch.h
 +++ b/arch/riscv32/syscall_arch.h
-@@ -76,3 +76,5 @@ static inline long __syscall6(long n, lo
+@@ -76,3 +76,5 @@ static inline long __syscall6(long n, long a, long b, long c, long d, long e, lo
  /* We don't have a clock_gettime function.
  #define VDSO_CGT_SYM "__vdso_clock_gettime"
  #define VDSO_CGT_VER "LINUX_2.6" */
 +
 +#define IPC_64 0
+diff --git a/src/process/waitpid.c b/src/process/waitpid.c
+index e5ff27ca..9de4073f 100644
 --- a/src/process/waitpid.c
 +++ b/src/process/waitpid.c
 @@ -3,5 +3,5 @@
@@ -166,3 +185,6 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 -	return __wait4(pid, status, options, 0, 1);
 +	return __syscall_ret(__wait4(pid, status, options, 0, 1));
  }
+-- 
+2.42.0
+

--- a/recipes-core/musl/musl/0010-Add-bits-reg.h-for-riscv32.patch
+++ b/recipes-core/musl/musl/0010-Add-bits-reg.h-for-riscv32.patch
@@ -1,7 +1,7 @@
-From 707914898f9b5a2738ad188942c3c730889f8f16 Mon Sep 17 00:00:00 2001
+From 86f469b5db2ce621602c21ee7c106ef856ecfac9 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Thu, 31 Dec 2020 16:07:38 -0800
-Subject: [PATCH] Add bits/reg.h for riscv32
+Subject: [PATCH 10/12] Add bits/reg.h for riscv32
 
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
@@ -20,5 +20,5 @@ index 00000000..0c7bffca
 +#define __WORDSIZE 32
 +/* FIXME */
 -- 
-2.30.0
+2.42.0
 

--- a/recipes-core/musl/musl/0011-riscv32-fix-inconsistent-ucontext_t-struct-tag.patch
+++ b/recipes-core/musl/musl/0011-riscv32-fix-inconsistent-ucontext_t-struct-tag.patch
@@ -1,7 +1,7 @@
-From d6cdbadb028f6b5bba46b2b223519ab372b42b42 Mon Sep 17 00:00:00 2001
+From 7d61a0c227ce1486de45f0a8b01a35e2345107dc Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 16 Mar 2022 10:57:18 -0700
-Subject: [PATCH] riscv32: fix inconsistent ucontext_t struct tag
+Subject: [PATCH 11/12] riscv32: fix inconsistent ucontext_t struct tag
 
 ucontext.h depends on the internal struct tag name for namespacing
 reasons, and the intent was always for it to be consistent across
@@ -31,5 +31,5 @@ index b006334f..287367db 100644
  	sigset_t uc_sigmask;
  	mcontext_t uc_mcontext;
 -- 
-2.35.1
+2.42.0
 

--- a/recipes-core/musl/musl/0012-riscv32-Wire-new-syscalls.patch
+++ b/recipes-core/musl/musl/0012-riscv32-Wire-new-syscalls.patch
@@ -1,8 +1,11 @@
-From 9fb8b132642520042ab4734ac1f0abce688bbea9 Mon Sep 17 00:00:00 2001
+From a6c49977772a200216bd3a63b490d467663384b6 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Fri, 30 Oct 2020 12:16:29 -0700
-Subject: [PATCH 16/16] riscv32: Wire new syscalls
+Subject: [PATCH 12/12] riscv32: Wire new syscalls
 
+- add mount_setattr from linux v5.12
+- add epoll_pwait2 from linux v5.11
+- add process_madvise from linux v5.10
 - add __NR_faccessat2 from linux v5.8
 - add pidfd_getfd and openat2 syscall numbers from linux v5.6
 - add clone3 syscall number from linux v5.3
@@ -10,14 +13,14 @@ Subject: [PATCH 16/16] riscv32: Wire new syscalls
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
- arch/riscv32/bits/syscall.h.in | 5 ++++-
- 1 file changed, 4 insertions(+), 1 deletion(-)
+ arch/riscv32/bits/syscall.h.in | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/arch/riscv32/bits/syscall.h.in b/arch/riscv32/bits/syscall.h.in
-index 852d2aaa..4b145fa3 100644
+index 852d2aaa..910b82c8 100644
 --- a/arch/riscv32/bits/syscall.h.in
 +++ b/arch/riscv32/bits/syscall.h.in
-@@ -279,7 +279,10 @@
+@@ -279,7 +279,16 @@
  #define __NR_fsmount		432
  #define __NR_fspick		433
  #define __NR_pidfd_open		434
@@ -26,9 +29,15 @@ index 852d2aaa..4b145fa3 100644
 +#define __NR_openat2		437
 +#define __NR_pidfd_getfd	438
 +#define __NR_faccessat2		439
++#define __NR_process_madvise	440
++#define __NR_epoll_pwait2	441
++#define __NR_mount_setattr	442
++#define __NR_landlock_create_ruleset	444
++#define __NR_landlock_add_rule	445
++#define __NR_landlock_restrict_self	446
  #define __NR_futex __NR_futex_time64
  
  #define __NR_sysriscv __NR_arch_specific_syscall
 -- 
-2.29.2
+2.42.0
 

--- a/recipes-core/musl/musl_%.bbappend
+++ b/recipes-core/musl/musl_%.bbappend
@@ -1,16 +1,16 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:riscv32 = "\
-    file://0007-Emulate-wait4-using-waitid.patch \
-    file://0008-riscv-Fall-back-to-syscall-__riscv_flush_icache.patch \
-    file://0009-riscv32-Target-and-subtarget-detection.patch \
-    file://0010-riscv32-add-arch-headers.patch \
-    file://0011-riscv32-Add-fenv-and-math.patch \
-    file://0012-riscv32-Add-dlsym.patch \
-    file://0013-riscv32-Add-jmp_buf-and-sigreturn.patch \
-    file://0014-riscv32-Add-thread-support.patch \
-    file://0015-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch \
-    file://0016-riscv32-Wire-new-syscalls.patch \
-    file://0017-Add-bits-reg.h-for-riscv32.patch \
-    file://0001-riscv32-fix-inconsistent-ucontext_t-struct-tag.patch \
+    file://0001-Emulate-wait4-using-waitid.patch \
+    file://0002-riscv-Fall-back-to-syscall-__riscv_flush_icache.patch \
+    file://0003-riscv32-Target-and-subtarget-detection.patch \
+    file://0004-riscv32-add-arch-headers.patch \
+    file://0005-riscv32-Add-fenv-and-math.patch \
+    file://0006-riscv32-Add-dlsym.patch \
+    file://0007-riscv32-Add-jmp_buf-and-sigreturn.patch \
+    file://0008-riscv32-Add-thread-support.patch \
+    file://0009-Change-definitions-of-F_GETLK-F_SETLK-F_SETLKW.patch \
+    file://0010-Add-bits-reg.h-for-riscv32.patch \
+    file://0011-riscv32-fix-inconsistent-ucontext_t-struct-tag.patch \
+    file://0012-riscv32-Wire-new-syscalls.patch \
 "


### PR DESCRIPTION
Add newly wired syscalls for riscv32 as well.

