### PR TITLE
Add addtional patch to fix build in riscv32 musl.

### DIFF
--- a/recipes-core/musl/musl/0013-riscv32-add-a_cas_p-to-atomic_arch.h.patch
+++ b/recipes-core/musl/musl/0013-riscv32-add-a_cas_p-to-atomic_arch.h.patch
@@ -1,0 +1,42 @@
+From 86ad9e4594b91652c64a88663250d5676519483a Mon Sep 17 00:00:00 2001
+From: "Michael T. Kloos" <michael@michaelkloos.com>
+Date: Mon, 6 Nov 2023 06:37:08 -0500
+Subject: [PATCH] riscv32: add a_cas_p to atomic_arch.h
+
+This is a modified version of the implementation for riscv64.  It
+fixes the build	error due to the missing arch specific
+implementation.
+
+Signed-off-by: Michael T. Kloos <michael@michaelkloos.com>
+---
+ arch/riscv32/atomic_arch.h | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/arch/riscv32/atomic_arch.h b/arch/riscv32/atomic_arch.h
+index 4d418f63..ae1a02dd 100644
+--- a/arch/riscv32/atomic_arch.h
++++ b/arch/riscv32/atomic_arch.h
+@@ -19,3 +19,20 @@ static inline int a_cas(volatile int *p, int t, int s)
+ 		: "memory");
+ 	return old;
+ }
++
++#define a_cas_p a_cas_p
++static inline void *a_cas_p(volatile void *p, void *t, void *s)
++{
++	void *old;
++	int tmp;
++	__asm__ __volatile__ (
++		"\n1:	lr.w.aqrl %0, (%2)\n"
++		"	bne %0, %3, 1f\n"
++		"	sc.w.aqrl %1, %4, (%2)\n"
++		"	bnez %1, 1b\n"
++		"1:"
++		: "=&r"(old), "=&r"(tmp)
++		: "r"(p), "r"(t), "r"(s)
++		: "memory");
++	return old;
++}
+-- 
+2.41.0
+


### PR DESCRIPTION
I attempted to build riscv32 musl libc using the patch set provided here, but encountered a build error.  This patch should fix the error.  I avoided modifying your existing patches to preserve authorship and the subsequent validity of sign-off statements.  
