### PR TITLE
milkv-duo: Add bootfile as image dependency

### DIFF
--- a/conf/machine/milkv-duo.conf
+++ b/conf/machine/milkv-duo.conf
@@ -26,6 +26,8 @@ UBOOT_MACHINE = " "
 UBOOT_ENTRYPOINT = "0x80200000"
 UBOOT_LOADADDRESS = "0x80200000"
 
+EXTRA_IMAGEDEPENDS += "milkv-duo-bootfiles"
+
 IMAGE_BOOT_FILES ?= " kernel.itb;boot.sd \
 	fip.bin"
 


### PR DESCRIPTION
Add milkv-duo-bootfiles to EXTRA_IMAGEDEPENDS so the fip.bin can be found when doing do_image_wic().

Signed-off-by: Yu Chien Peter Lin <mail@yclin.org>
