### PR TITLE
Update VisionFive2 to Upstream 3.9.3 release and switch to Kernel 6.1

### DIFF
--- a/recipes-bsp/common/visionfive2-firmware.inc
+++ b/recipes-bsp/common/visionfive2-firmware.inc
@@ -1,6 +1,6 @@
-VISIONFIVE2FW_DATE ?= "20230926"
-# VF2_v3.7.5
-SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=7208ad2ab2f7968648fe17b37aa5e3db11ad40f0"
+VISIONFIVE2FW_DATE ?= "20231205"
+# VF2_v3.9.3
+SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=12d2bb46f364ed375268280b757ee31b2113c76a"
 HOMEPAGE ?= "https://github.com/starfive-tech/soft_3rdpart"
 
 IMG_GPU_POWERVR_VERSION = "img-gpu-powervr-bin-1.19.6345021"

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -8,12 +8,12 @@ KERNEL_VERSION_SANITY_SKIP = "1"
 SRCREV = "${AUTOREV}"
 
 # pin srcrev for now to have a fixed target
-# release VF2_v3.7.5
-SRCREV:visionfive2 = "cd3629d462ee08405b02a490400f06fa314161f9"
+# release VF2_v3.9.3
+SRCREV:visionfive2 = "39daafe74ea5e5c56c56af673e7488783873d810"
 SRCREV:star64 = "e4c0928f1e42ed82ab9fa8918bc7094d3c0414d8"
 
 BRANCH = "visionfive"
-BRANCH:visionfive2 = "JH7110_VisionFive2_devel"
+BRANCH:visionfive2 = "JH7110_VisionFive2_6.1.y_devel"
 BRANCH:star64 = "Star64_devel"
 
 FORK ?= "starfive-tech"
@@ -35,13 +35,17 @@ SRC_URI:append:visionfive = " \
            file://extra.cfg \
 "
 
-SRC_URI:append:jh7110 = " \
-           file://visionfive2-graphics.cfg \
+SRC_URI:jh7110 = " \
+           git://github.com/${FORK}/${REPO}.git;protocol=https;branch=${BRANCH} \
+           file://0001-riscv-disable-generation-of-unwind-tables.patch \
+           file://0001-gcc-plugins-Fix-build-for-upcoming-GCC-release-kernel61.patch \
            file://0001-Allow-building-of-PVR-GPU-driver-as-module.patch \
+           file://visionfive2-graphics.cfg \
+           file://modules.cfg \
 "
 
 LINUX_VERSION ?= "6.2.0"
-LINUX_VERSION:jh7110 = "5.15.0"
+LINUX_VERSION:jh7110 = "6.1.0"
 LINUX_VERSION_EXTENSION:append:beaglev-starlight-jh7100 = "-starlight"
 
 KBUILD_DEFCONFIG:beaglev-starlight-jh7100 = "starfive_jh7100_fedora_defconfig"

--- a/recipes-kernel/linux/linux-starfive/0001-gcc-plugins-Fix-build-for-upcoming-GCC-release-kernel61.patch
+++ b/recipes-kernel/linux/linux-starfive/0001-gcc-plugins-Fix-build-for-upcoming-GCC-release-kernel61.patch
@@ -1,0 +1,49 @@
+From 8e12e70503b23d2bfe430e8e81c737aa8f2b81c1 Mon Sep 17 00:00:00 2001
+From: Palmer Dabbelt <palmer@rivosinc.com>
+Date: Fri, 13 Jan 2023 09:30:33 -0800
+Subject: [PATCH] gcc-plugins: Fix build for upcoming GCC release
+
+The upcoming GCC release has refactored the gimple plugin interface a
+bit and unless gimple-iterator.h is included before gimple-fold.h I end
+up with a bunch of missing declarations when building the stack
+protector plugin.
+
+Upstream-Status: Backport [https://lore.kernel.org/all/20230113173033.4380-1-palmer@rivosinc.com/]
+Reported-by: Palmer Dabbelt <palmer@rivosinc.com>
+Acked-by: Palmer Dabbelt <palmer@rivosinc.com>
+Link: https://lore.kernel.org/all/20230113173033.4380-1-palmer@rivosinc.com/
+Cc: linux-hardening@vger.kernel.org
+Signed-off-by: Kees Cook <keescook@chromium.org>
+---
+ scripts/gcc-plugins/gcc-common.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/gcc-plugins/gcc-common.h b/scripts/gcc-plugins/gcc-common.h
+index 9a1895747b15..84c730da36dd 100644
+--- a/scripts/gcc-plugins/gcc-common.h
++++ b/scripts/gcc-plugins/gcc-common.h
+@@ -71,7 +71,9 @@
+ #include "varasm.h"
+ #include "stor-layout.h"
+ #include "internal-fn.h"
++#include "gimple.h"
+ #include "gimple-expr.h"
++#include "gimple-iterator.h"
+ #include "gimple-fold.h"
+ #include "context.h"
+ #include "tree-ssa-alias.h"
+@@ -85,10 +87,8 @@
+ #include "tree-eh.h"
+ #include "stmt.h"
+ #include "gimplify.h"
+-#include "gimple.h"
+ #include "tree-phinodes.h"
+ #include "tree-cfg.h"
+-#include "gimple-iterator.h"
+ #include "gimple-ssa.h"
+ #include "ssa-iterators.h"
+
+
+-- 
+2.41.0
+


### PR DESCRIPTION
Upstream now provides to release tracks with supporting both Kernels 5.15 and 6.1. This update uses the 3.9.3 upstream release and switches to the Linux 6.1 Kernel. Basic functionality (including graphics) was tested with a meta-kde demo setup on a Qt6 stack.