### PR TITLE
Update VisionFive-2 to StarFive SDK release 5.10.3

### DIFF
--- a/recipes-bsp/common/visionfive2-firmware.inc
+++ b/recipes-bsp/common/visionfive2-firmware.inc
@@ -1,6 +1,6 @@
-VISIONFIVE2FW_DATE ?= "20231205"
-# VF2_v3.9.3
-SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=12d2bb46f364ed375268280b757ee31b2113c76a"
+VISIONFIVE2FW_DATE ?= "20231221^"
+# JH7110_VF2_6.1_v5.10.3
+SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=819f2f5da8997689e3814daad4b683c92b6ce8c2"
 HOMEPAGE ?= "https://github.com/starfive-tech/soft_3rdpart"
 
 IMG_GPU_POWERVR_VERSION = "img-gpu-powervr-bin-1.19.6345021"

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -8,8 +8,8 @@ KERNEL_VERSION_SANITY_SKIP = "1"
 SRCREV = "${AUTOREV}"
 
 # pin srcrev for now to have a fixed target
-# release VF2_v3.9.3
-SRCREV:visionfive2 = "39daafe74ea5e5c56c56af673e7488783873d810"
+# release JH7110_VF2_6.1_v5.10.3
+SRCREV:visionfive2 = "a77eaf219c34156e52298a6ab2357aaa4251df8b"
 SRCREV:star64 = "e4c0928f1e42ed82ab9fa8918bc7094d3c0414d8"
 
 BRANCH = "visionfive"


### PR DESCRIPTION
Despite the big version number change, this is a small bugfix update by SF mostly with changes for video processing and some fixes around HDMI: https://forum.rvspace.org/t/visionfive2-software-v5-10-3-release/3988
Build and tested successfully on my device with a KDE Plasma Wayland session.