### PR TITLE
visionfive2-firmware: Fix visionfive2 U-Boot build

### DIFF
--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -10,7 +10,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 BRANCH:visionfive2 = "JH7110_VisionFive2_devel"
 BRANCH:star64 = "Star64"
 
-SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;branch=${BRANCH} \
+SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;nobranch=1 \
            file://tftp-mmc-boot.txt \
           "
 
@@ -27,8 +27,8 @@ SRC_URI:append:star64 = " \
 "
 
 
-# tag VF2_v3.6.1
-SRCREV:visionfive2 = "7f96b15e26f14df56fa9d480c0cc6f7434997360"
+# tag JH7110_VF2_6.1_v5.10.3
+SRCREV:visionfive2 = "8c7b3f31fb546f829bbce9ee52435342314fabbf"
 SRCREV:star64 = "c71fa7376f4eaf29e2dc20e5a68418d79201290a"
 
 


### PR DESCRIPTION
u-boot-starfive_v2021.10.bb: The rev 7f96b15e26f1 is no longer on the branch JH7110_VisionFive2_devel, so fetching fails.  This revision is the same as the tag VF2_v3.6.1 so specify nobranch=1 instead of a branch name for this revision.

This resolves the following errors:
WARNING: u-boot-starfive-1_v2021.10-r0 do_fetch: Failed to fetch URL git://github.com/starfive-tech/u-boot.git;protocol=https;branch=JH7110_VisionFive2_devel, attempting MIRRORS if available
ERROR: u-boot-starfive-1_v2021.10-r0 do_fetch: Fetcher failure: Unable to find revision 7f96b15e26f14df56fa9d480c0cc6f7434997360 in branch JH7110_VisionFive2_devel even from upstream
ERROR: u-boot-starfive-1_v2021.10-r0 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'git://github.com/starfive-tech/u-boot.git;protocol=https;branch=JH7110_VisionFive2_devel')
ERROR: Logfile of failure stored in: /data/rfranz/tmp/yoe/build/tmp/work/visionfive2-yoe-linux/u-boot-starfive/v2021.10/temp/log.do_fetch.1782
ERROR: Task (/data/rfranz/tmp/yoe/sources/meta-riscv/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb:do_fetch) failed with exit code '1'

Signed-off-by: Roy Franz <rfranz@tenstorrent.com>


I'm not sure if this is the proper way to fix this failure.  From reading the Yocto documentation, it seems that fetching by tag name is not usually used because that requires network access.

