### PR TITLE
linux-allwinnerd1-dev:  Fix module loading

### DIFF
--- a/recipes-kernel/linux/linux-allwinnerd1-dev.bb
+++ b/recipes-kernel/linux/linux-allwinnerd1-dev.bb
@@ -6,7 +6,7 @@ SRCREV_machine ?= "ca67838d84af4c9f85d06311c9e98e1adf46308f"
 FORK ?= "smaeul"
 BRANCH ?= "riscv/d1-wip"
 KMETA = "kernel-meta"
-
+export KCFLAGS="-fno-asynchronous-unwind-tables -fno-unwind-tables"
 # It is necessary to add to SRC_URI link to the 'yocto-kernel-cache' due to
 # override of the original SRC_URI:
 # "do_kernel_metadata: Check the SRC_URI for meta-data repositories or


### PR DESCRIPTION
Compile kernel with -fno-asynchronous-unwind-tables -fno-unwind-tables to fix kernel modules failures [2]. This is workaround until [1] is merged.

[1] https://lore.kernel.org/lkml/20231101-module_relocations-v9-2-8dfa3483c400@rivosinc.com/#r
[2] unknown relocation type 57
