### PR TITLE
rtl8723ds: Fix module loading

### DIFF
--- a/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
+++ b/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
@@ -4,6 +4,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1f6f1c0be32491a0c8d2915607a28f36"
 
 inherit module
+export KCFLAGS="-fno-asynchronous-unwind-tables -fno-unwind-tables"
 
 SRCREV = "ec85dc6b9f72bfe413bff464ed01a272e29c8dbe"
 


### PR DESCRIPTION
If built with gcc 13 module cannot be loaded with [2]. Apply workaround until [1] is merged.
Tested with MangoPi MQ-Pro

[1] https://lore.kernel.org/lkml/20231101-module_relocations-v9-2-8dfa3483c400@rivosinc.com/#r
[2] unknown relocation type 57
