### PR TITLE
capnproto,pidgin-sipe: Re-enable on rv32

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -159,10 +159,3 @@ COMPATIBLE_HOST:pn-samba:riscv32 = "null"
 COMPATIBLE_HOST:pn-smbnetfs:riscv32 = "null"
 COMPATIBLE_HOST:pn-gnome-control-center:riscv32 = "null"
 COMPATIBLE_HOST:pn-thunar-shares-plugin:riscv32 = "null"
-
-# sipe-mime.c:129:30: error: cast from 'GTypeInstance *' (aka 'struct _GTypeInstance *') to 'GMimeStreamFilter *' (aka 'struct _GMimeStreamFilter *') increases required al ignment from 4 to 8 [-Werror,-Wcast-align]
-COMPATIBLE_HOST:pn-pidgin-sipe:riscv32 = "null"
-
-# needs swapcontext/makecontext/getcontext which are
-# not yet implemented in linucontext for rv32
-COMPATIBLE_HOST:pn-capnproto:libc-musl:riscv32 = "null"


### PR DESCRIPTION
They compile fine with musl/glibc on rv32 now.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

