### PR TITLE
VisionFive2 JH7110_VF2_6.1_v5.11.3

### DIFF
--- a/recipes-bsp/common/visionfive2-firmware.inc
+++ b/recipes-bsp/common/visionfive2-firmware.inc
@@ -1,6 +1,6 @@
 VISIONFIVE2FW_DATE ?= "20231221^"
-# JH7110_VF2_6.1_v5.10.3
-SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel;rev=819f2f5da8997689e3814daad4b683c92b6ce8c2"
+# JH7110_VF2_6.1_v5.11.3
+SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;nobranch=1;rev=5eca20d2ce6fb7b18044bfe30c5bfd7f8f47958d"
 HOMEPAGE ?= "https://github.com/starfive-tech/soft_3rdpart"
 
 IMG_GPU_POWERVR_VERSION = "img-gpu-powervr-bin-1.19.6345021"

--- a/recipes-bsp/jh7110-spl-tool/jh7110-spl-tool_git.bb
+++ b/recipes-bsp/jh7110-spl-tool/jh7110-spl-tool_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e6dc25dc2418b8831c906d43809d8336"
 SECTION = "bootloaders"
 
-SRCREV = "8c5acc4e5eb7e4ad012463b05a5e3dbbfed1c38d"
+SRCREV = "0747c0510e090f69bf7d2884f44903b77b3db5c5"
 SRC_URI = "git://github.com/starfive-tech/Tools;protocol=https;branch=master"
 
 S = "${WORKDIR}/git/spl_tool"

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -30,8 +30,8 @@ SRC_URI:append:star64 = " \
 "
 
 
-# tag JH7110_VF2_6.1_v5.10.3
-SRCREV:visionfive2 = "8c7b3f31fb546f829bbce9ee52435342314fabbf"
+# tag JH7110_VF2_6.1_v5.11.3
+SRCREV:visionfive2 = "223ac8b1e907924d3891b3be1b2f6620b56bff31"
 SRCREV:star64 = "c71fa7376f4eaf29e2dc20e5a68418d79201290a"
 
 

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -8,13 +8,13 @@ KERNEL_VERSION_SANITY_SKIP = "1"
 SRCREV = "${AUTOREV}"
 
 # pin srcrev for now to have a fixed target
-# release JH7110_VF2_6.1_v5.10.3
-SRCREV:visionfive2 = "a77eaf219c34156e52298a6ab2357aaa4251df8b"
+# release JH7110_VF2_6.1_v5.11.3
+SRCREV:visionfive2 = "18425cfe66cef584b243fba4966d8e0322880c7a"
 SRCREV:star64 = "e4c0928f1e42ed82ab9fa8918bc7094d3c0414d8"
 
-BRANCH = "visionfive"
-BRANCH:visionfive2 = "JH7110_VisionFive2_6.1.y_devel"
-BRANCH:star64 = "Star64_devel"
+BRANCH = "branch=visionfive"
+BRANCH:visionfive2 = "nobranch=1"
+BRANCH:star64 = "branch=Star64_devel"
 
 FORK ?= "starfive-tech"
 FORK:star64 ?= "Fishwaldo"
@@ -22,7 +22,7 @@ FORK:star64 ?= "Fishwaldo"
 REPO ?= "linux"
 REPO:star64 ?= "Star64_linux"
 
-SRC_URI = "git://github.com/${FORK}/${REPO}.git;protocol=https;branch=${BRANCH} \
+SRC_URI = "git://github.com/${FORK}/${REPO}.git;protocol=https;${BRANCH} \
            file://0001-riscv-disable-generation-of-unwind-tables.patch \
            file://0001-gcc-plugins-Fix-build-for-upcoming-GCC-release.patch \
            file://0001-riscv-fix-building-external-modules.patch \
@@ -39,7 +39,7 @@ SRC_URI:append:visionfive = " \
 "
 
 SRC_URI:jh7110 = " \
-           git://github.com/${FORK}/${REPO}.git;protocol=https;branch=${BRANCH} \
+           git://github.com/${FORK}/${REPO}.git;protocol=https;${BRANCH} \
            file://0001-riscv-disable-generation-of-unwind-tables.patch \
            file://0001-gcc-plugins-Fix-build-for-upcoming-GCC-release-kernel61.patch \
            file://0001-Allow-building-of-PVR-GPU-driver-as-module.patch \


### PR DESCRIPTION
VisionFive2 JH7110_VF2_6.1_v5.11.3 update

```
 Static hostname: visionfive2
       Icon name: computer
      Machine ID: 843ee583e62542e5a4255df63c21ed19
         Boot ID: 8f95fea41d3d4d0398212bf9c938f2bf
Operating System: Poky (Yocto Project Reference Distro) 4.3+snapshot-b5624ee5643d881afa004571a096a189ab5389b5 (scarthgap)
     CPE OS Name: cpe:/o:openembedded:poky:4.3+snapshot-b5624ee5643d881afa004571a096a189ab5389b5
          Kernel: Linux 6.1.31
    Architecture: riscv64
```

[v4l2-info.log](https://github.com/riscv/meta-riscv/files/14733058/v4l2-info.log)
[visionfive2_dmesg.log](https://github.com/riscv/meta-riscv/files/14733060/visionfive2_dmesg.log)
