### PR TITLE
mesa-pvr: Mark it machine arch package

### DIFF
--- a/recipes-graphics/mesa/mesa-pvr.inc
+++ b/recipes-graphics/mesa/mesa-pvr.inc
@@ -241,6 +241,10 @@ PACKAGECONFIG[unwind] = "-Dlibunwind=enabled,-Dlibunwind=disabled,libunwind"
 
 PACKAGECONFIG[lmsensors] = "-Dlmsensors=enabled,-Dlmsensors=disabled,lmsensors"
 
+# it might conflict with other RISCV builds of mesa e.g. qemuriscv64 which uses
+# Upstream mesa
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 # llvmpipe is slow if compiled with -fomit-frame-pointer (e.g. -O2)
 FULL_OPTIMIZATION:append = " -fno-omit-frame-pointer"
 


### PR DESCRIPTION
It conflicts with upstream mesa builds otherwise from core layer, in multi machine build e.g. when builds for qemuriscv64 are done in same project then packaging for mesa-pvr and mesa would conflict since both provide same packages and duplicate file staging errors happen e.g.

ERROR: mesa-pvr-2_22.1.3-r0 do_create_spdx: Recipe mesa-pvr is trying to install files into a shared area when those files already exist. The files and the manifests listing them are:
  /mnt/b/yoe/master/build/tmp/deploy/spdx/riscv64/packages/libgl-mesa-dev.spdx.json
    (matched in manifest-riscv64-mesa.create_spdx)

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

