### PR TITLE
star64: fix u-boot compilation

### DIFF
--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -48,7 +48,7 @@ do_configure:prepend() {
         -d ${WORKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
 }
 
-do_deploy:append:jh7110() {
+do_deploy:append:visionfive2() {
     install -m 644 ${WORKDIR}/uEnv-visionfive2.txt ${DEPLOYDIR}/vf2_uEnv.txt
     spl_tool -c -f ${DEPLOYDIR}/${SPL_IMAGE}
     ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_BINARYNAME}.normal.out


### PR DESCRIPTION
Make sure that the do_install step is applied to the correct boards. `do_install:append:jh7110` was executed for star64 also (since it is based on the jh7110 SoC as well), however the installed file is only used for visionfive2 board, failing the build.

This change ensures that this file is only installed for visionfive2 board, and not for star64.

Fixes #471 
