### PR TITLE
visionfive2-pvr-graphics: fix installation with SysV init

### DIFF
--- a/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
@@ -23,7 +23,7 @@ PACKAGES += " \
 do_install () {
     tar xz --no-same-owner -f ${S}/IMG_GPU/out/${IMG_GPU_POWERVR_VERSION}.tar.gz -C ${D}
     mv ${D}/${IMG_GPU_POWERVR_VERSION}/target/* ${D}
-    install -d ${D}${includedir} ${D}${bindir}
+    install -d ${D}${includedir} ${D}${sysconfdir}/init.d
     cp -r ${D}/${IMG_GPU_POWERVR_VERSION}/staging/usr/include/drv/ ${D}/usr/include/
     cp -r ${D}/${IMG_GPU_POWERVR_VERSION}/staging/usr/include/GLES/ ${D}/usr/include/
     cp -r ${D}/${IMG_GPU_POWERVR_VERSION}/staging/usr/include/GLES2/ ${D}/usr/include/
@@ -32,7 +32,8 @@ do_install () {
     cp -r ${D}/${IMG_GPU_POWERVR_VERSION}/staging/usr/lib/pkgconfig/* ${D}/usr/lib/pkgconfig/
     install -Dm0644 ${WORKDIR}/glesv1_cm.pc ${D}${libdir}/pkgconfig/glesv1_cm.pc
     sed -i -e 's|^#!/bin/bash|#!/usr/bin/env sh|g' ${D}${sysconfdir}/init.d/rc.pvr
-    if [ ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)} ]; then
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${bindir}
         mv ${D}${sysconfdir}/init.d/rc.pvr ${D}${bindir}
         rmdir ${D}${sysconfdir}/init.d
         install -Dm 644 ${WORKDIR}/rc.pvr.service ${D}/${systemd_unitdir}/system/rc.pvr.service


### PR DESCRIPTION
Fix the installation of this recipe when using SysV init system by fixig the "if" condition that checks the presence of systemd in DISTRO_FEATURES - beforehand it was always evaluated as "true".

Beside this the required folders are also created when they should be: in case of SysV init the /usr/bin folder stays empty (and bitbake complains), so it is only created when systemd is used.

Similarly, /etc/init.d is used only by SysV init system, but the recipe already handles it when systemd is used. However if the folder is not installed explicitly, the do_rootfs task fails.

Fixes #473 
