### PR TITLE
u-boot-starfive: Emit boot.scr.uimg into builddir instead of workdir

### DIFF
--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -45,7 +45,7 @@ TFTP_SERVER_IP ?= "127.0.0.1"
 do_configure:prepend() {
     sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${UNPACKDIR}/tftp-mmc-boot.txt
     mkimage -O linux -T script -C none -n "U-Boot boot script" \
-        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
+        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${B}/${UBOOT_ENV_BINARY}
 }
 
 do_deploy:append:visionfive2() {


### PR DESCRIPTION
Fixes 2023.10 build on vf2
| install: cannot stat '/mnt/b/yoe/master/build/tmp/work/visionfive2-yoe-linux/u-boot-starfive/v2021.10/build/boot.scr.uimg': No such file or directory

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

