### PR TITLE
linux-milkv-duo[-dev]: replace WORKDIR with UNPACKDIR in do_deploy

### DIFF
--- a/recipes-kernel/linux/linux-milkv-duo-dev.bb
+++ b/recipes-kernel/linux/linux-milkv-duo-dev.bb
@@ -28,7 +28,7 @@ do_deploy[depends] = "milkv-duo-fsbl:do_deploy"
 
 do_deploy:append() {
 	cp ${SDIR}/Image.gz ${B}
-	cp ${WORKDIR}/multi.its ${B}
+	cp ${UNPACKDIR}/multi.its ${B}
 	mkimage -f ${B}/multi.its ${B}/uImage.fit
 	install -m 744 ${B}/uImage.fit ${DEPLOYDIR}
 	install -m 744 ${SDIR}/dts/${KERNEL_DEVICETREE} ${DEPLOYDIR}/default.dtb

--- a/recipes-kernel/linux/linux-milkv-duo.bb
+++ b/recipes-kernel/linux/linux-milkv-duo.bb
@@ -28,7 +28,7 @@ do_deploy[depends] = "milkv-duo-fsbl:do_deploy"
 
 do_deploy:append:milkv-duo() {
 	cp ${B}/arch/riscv/boot/Image.gz ${B}
-	cp ${WORKDIR}/multi.its ${B}
+	cp ${UNPACKDIR}/multi.its ${B}
 	mkimage -f ${B}/multi.its ${B}/uImage.fit
 	install -m 744 ${B}/uImage.fit ${DEPLOYDIR}
 	install -m 744 ${B}/arch/riscv/boot/dts/${KERNEL_DEVICETREE} ${DEPLOYDIR}/default.dtb


### PR DESCRIPTION
Trying to bitbake milkv-duo machine triggers the following error:

| cp: cannot stat 'riscv-yocto/build/tmp/work/milkv_duo-poky-linux/
linux-milkv-duo-dev/1.0/multi.its': No such file or directory

| cp: cannot stat 'riscv-yocto/build/tmp/work/milkv_duo-poky-linux/ linux-milkv-duo/6.8++gitAUTOINC+b95f2066a9/multi.its': No such file or directory

This is caused by multi.its file being in UNPACKDIR instead of WORKDIR, following the recent upstream changes in OE.

Signed-off-by: Hiago De Franco <hiagofranco@gmail.com>
(cherry picked from commit d44347617c2802edd067a16d2d8bc96c861b8325)

