### PR TITLE
python3-pyruvate: Use UNPACKDIR to reach patchdir in SRC_URI

### DIFF
--- a/dynamic-layers/meta-python/recipes-devtools/python/python3-pyruvate_%.bbappend
+++ b/dynamic-layers/meta-python/recipes-devtools/python/python3-pyruvate_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:riscv32 = "\
-    file://0001-statfs-Exclude-riscv32.patch;patchdir=../cargo_home/bitbake/nix-0.23.2/ \
+    file://0001-statfs-Exclude-riscv32.patch;patchdir=${UNPACKDIR}/cargo_home/bitbake/nix-0.23.2/ \
 "


### PR DESCRIPTION
This is needed after introduction of UNPACKDIR port scarthgap release

