### PR TITLE
Use scarthgap branch in oe.yml (fixes scarthgap build)

### DIFF
--- a/kas/include/oe.yml
+++ b/kas/include/oe.yml
@@ -5,7 +5,7 @@ repos:
   poky:
     url: https://git.yoctoproject.org/git/poky
     path: layers/poky
-    branch: master
+    branch: scarthgap
     layers:
       meta:
       meta-poky:
@@ -14,7 +14,7 @@ repos:
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded
     path: layers/meta-openembedded
-    branch: master
+    branch: scarthgap
     layers:
       meta-oe:
       meta-networking:


### PR DESCRIPTION
It will be better to use specific release branch for oe/poky layers instead of master, because currently it throws layer compatibility error. It is similar to oe.yml in meta-riscv kirkstone branch, where branch kirkstone instead of master is used for oe/poky.

At this time, master in poky repo is compatible only with mickledore, scarthgap and nanbield.