### PR TITLE
Fix PIE support for baremetal RISC-V

### DIFF
--- a/conf/machine/baremetal-riscv64.conf
+++ b/conf/machine/baremetal-riscv64.conf
@@ -4,3 +4,6 @@
 
 require include/baremetal-riscv.inc
 DEFAULTTUNE = "riscv64"
+
+# Override the GCCPIE flag to an empty string to support PIE with the elf toolchain
+GCCPIE = ""


### PR DESCRIPTION
Related to #345

Override the `GCCPIE` flag to an empty string in `conf/machine/baremetal-riscv64.conf`.

* Add a comment explaining the reason for the override to support PIE with the elf toolchain.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/riscv/meta-riscv/issues/345?shareId=7217c3a5-3787-409a-a4a0-45c84be606d1).