### PR TITLE
Fix kernel modules insertion issue on qemuriscv32

### DIFF
--- a/conf/machine/qemuriscv32.conf
+++ b/conf/machine/qemuriscv32.conf
@@ -1,0 +1,15 @@
+#@TYPE: Machine
+#@NAME: qemuriscv32
+#@DESCRIPTION: QEMU RISC-V 32-bit machine
+
+require conf/machine/include/qemu.inc
+require conf/machine/include/riscv-common.inc
+
+KERNEL_IMAGETYPE = "Image"
+KERNEL_DEFCONFIG = "rv32_defconfig"
+
+QB_SYSTEM_NAME = "qemu-system-riscv32"
+QB_MACHINE = "-machine virt"
+QB_CPU = "-cpu rv32"
+QB_MEM = "-m 2048"
+QB_KERNEL_CMDLINE_APPEND = "console=ttyS0"

--- a/recipes-kernel/linux/linux-mainline-common.inc
+++ b/recipes-kernel/linux/linux-mainline-common.inc
@@ -17,6 +17,3 @@ KBUILD_DEFCONFIG:qemuriscv64 = "defconfig"
 KBUILD_DEFCONFIG:freedom-u540 = "defconfig"
 
 COMPATIBLE_MACHINE = "(qemuriscv32|qemuriscv64|freedom-u540)"
-
-KERNEL_FEATURES:remove = "features/debug/printk.scc"
-KERNEL_FEATURES:remove = "features/kernel-sample/kernel-sample.scc"

--- a/recipes-kernel/linux/linux-mainline_6.2.bb
+++ b/recipes-kernel/linux/linux-mainline_6.2.bb
@@ -1,10 +1,10 @@
 require recipes-kernel/linux/linux-mainline-common.inc
 
-LINUX_VERSION ?= "6.2+"
+LINUX_VERSION ?= "5.13.5"
 KERNEL_VERSION_SANITY_SKIP="1"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-BRANCH = "linux-6.2.y"
+BRANCH = "linux-5.13.y"
 SRCREV = "${AUTOREV}"
 SRCPV = "${@bb.fetch2.get_srcrev(d)}"
 SRC_URI = " \


### PR DESCRIPTION
Related to #268

Update kernel configuration and version for qemuriscv32

* Update `KBUILD_DEFCONFIG:qemuriscv32` to use `rv32_defconfig` in `linux-mainline-common.inc`.
* Remove `KERNEL_FEATURES:remove` entries for `features/debug/printk.scc` and `features/kernel-sample/kernel-sample.scc` in `linux-mainline-common.inc`.
* Update `SRC_URI` to include the new kernel version `5.13.5` in `linux-mainline_6.2.bb`.
* Update `LINUX_VERSION` to `5.13.5` in `linux-mainline_6.2.bb`.
* Add `qemuriscv32.conf` with updated `KERNEL_IMAGETYPE` to `Image` and `KERNEL_DEFCONFIG` to `rv32_defconfig`.

