### PR TITLE
Add NAND support for Milk-V Duo

### DIFF
--- a/conf/machine/milkv-duo.conf
+++ b/conf/machine/milkv-duo.conf
@@ -31,6 +31,9 @@ IMAGE_BOOT_FILES ?= " \
                     fip.bin \
                     uEnv.txt \
                     uImage.fit \
+                    boot.spinand \
+                    rootfs.spinand \
+                    system.spinand \
                     "
 
-WKS_FILE ?= "milkv-duo.wks"
+WKS_FILE ?= "milkv-duo-spinand.wks"

--- a/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
+++ b/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
@@ -39,7 +39,8 @@ do_compile () {
 		--BLCP_2ND_RUNADDR=0x83f40000 \
 		--DDR_PARAM=${S}/test/cv181x/ddr_param.bin \
 		--MONITOR=${DEPLOY_DIR_IMAGE}/fw_dynamic.bin \
-		--LOADER_2ND=${DEPLOY_DIR_IMAGE}/u-boot.bin
+		--LOADER_2ND=${DEPLOY_DIR_IMAGE}/u-boot.bin \
+		--NAND_BOOT=1
 }
 
 do_deploy () {

--- a/recipes-bsp/u-boot/files/milkv-duo-support-files.patch
+++ b/recipes-bsp/u-boot/files/milkv-duo-support-files.patch
@@ -267,9 +267,8 @@ index 0000000000..5d8ccce059
 +	};
 +};
 diff --git a/configs/milkv-duo_defconfig b/configs/milkv-duo_defconfig
-new file mode 100644
-index 0000000000..2fcbd2bfea
---- /dev/null
+index 2fcbd2bfea..d3c8f2bfea 100644
+--- a/configs/milkv-duo_defconfig
 +++ b/configs/milkv-duo_defconfig
 @@ -0,0 +1,78 @@
 +CONFIG_RISCV=y
@@ -321,7 +320,6 @@ index 0000000000..2fcbd2bfea
 +CONFIG_CMD_PART=y
 +# CONFIG_CMD_ITEST is not set
 +# CONFIG_CMD_SOURCE is not set
-+# CONFIG_CMD_SETEXPR is not set
 +CONFIG_CMD_DHCP=y
 +# CONFIG_CMD_NFS is not set
 +CONFIG_CMD_PING=y
@@ -350,9 +348,12 @@ index 0000000000..2fcbd2bfea
 +CONFIG_LZMA=y
 +# CONFIG_EFI_LOADER is not set
 +# CONFIG_TOOLS_LIBCRYPTO is not set
++CONFIG_CMD_NAND=y
++CONFIG_MTD=y
++CONFIG_MTD_RAW_NAND=y
++CONFIG_NAND_CVITEK=y
 diff --git a/include/milkv-duo.env b/include/milkv-duo.env
-new file mode 100644
-index 0000000000..7875d99fdc
+index 0000000000..7875d99fdc 100644
 --- /dev/null
 +++ b/include/milkv-duo.env
 @@ -0,0 +1,3 @@

--- a/wic/milkv-duo-spinand.wks
+++ b/wic/milkv-duo-spinand.wks
@@ -1,0 +1,6 @@
+# short-description: Create NAND image for Milk-V Duo development board
+
+part /boot --source bootimg-partition --ondisk nand0 --fstype=vfat --label boot --active --fixed-size 64M --align 4096
+part / --source rootfs --ondisk nand0 --fstype=ext4 --label root --align 4096 --size 128M
+part /system --source rootfs --ondisk nand0 --fstype=ext4 --label system --align 4096 --size 256M
+part /data --source rootfs --ondisk nand0 --fstype=ext4 --label data --align 4096 --size 512M


### PR DESCRIPTION
Related to #487

Add support for creating NAND image for Milk-V Duo in Yocto layer.

* **conf/machine/milkv-duo.conf**
  - Add NAND-specific configurations.
  - Update `IMAGE_BOOT_FILES` to include `boot.spinand`, `fip.bin`, `rootfs.spinand`, and `system.spinand`.
  - Update `WKS_FILE` to use `milkv-duo-spinand.wks`.

* **wic/milkv-duo-spinand.wks**
  - Create a new `wic/milkv-duo-spinand.wks` file for NAND image creation.
  - Add partitions for `boot.spinand`, `fip.bin`, `rootfs.spinand`, and `system.spinand`.

* **recipes-bsp/u-boot/files/milkv-duo-support-files.patch**
  - Add NAND-specific configurations.
  - Update `milkv-duo_defconfig` to include NAND support.

* **recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb**
  - Add NAND-specific configurations.
  - Update `do_compile` to include NAND-specific parameters.

