### PR TITLE
Force the kernel git fecther protocol to be 'https'

### DIFF
--- a/recipes-kernel/linux/linux-mainline_6.2.bb
+++ b/recipes-kernel/linux/linux-mainline_6.2.bb
@@ -8,5 +8,5 @@ BRANCH = "linux-6.2.y"
 SRCREV = "${AUTOREV}"
 SRCPV = "${@bb.fetch2.get_srcrev(d)}"
 SRC_URI = " \
-    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;branch=${BRANCH} \
+    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protocol=https;branch=${BRANCH} \
 "

--- a/recipes-kernel/linux/linux-milkv-duo.bb
+++ b/recipes-kernel/linux/linux-milkv-duo.bb
@@ -10,7 +10,7 @@ BRANCH = "linux-6.8.y"
 SRCREV = "v6.8.5"
 SRCPV = "${@bb.fetch2.get_srcrev(d)}"
 SRC_URI = " \
-	git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;branch=${BRANCH} \
+	git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protocol=https;branch=${BRANCH} \
 	file://017199c2849c3d6d417791ec1cf5521005d663a1.patch \
 	file://riscv-dts-sophgo-add-sdcard-support-for-milkv-duo.patch \
 	file://sophgo-add-reboot-shutdown-driver.patch \


### PR DESCRIPTION
By default, the git fetcher protocol will be 'git', this will cause issue when you behind a firewall.

Change them to 'https' will help to resolve these issues.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

