### PR TITLE
milkv-duo-fsbl: Delete non-existing NAND_BOOT argument

### DIFF
--- a/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
+++ b/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
@@ -39,8 +39,7 @@ do_compile () {
 		--BLCP_2ND_RUNADDR=0x83f40000 \
 		--DDR_PARAM=${S}/test/cv181x/ddr_param.bin \
 		--MONITOR=${DEPLOY_DIR_IMAGE}/fw_dynamic.bin \
-		--LOADER_2ND=${DEPLOY_DIR_IMAGE}/u-boot.bin \
-		--NAND_BOOT=1
+		--LOADER_2ND=${DEPLOY_DIR_IMAGE}/u-boot.bin
 }
 
 do_deploy () {


### PR DESCRIPTION
plat/cv180x/fiptool.py does not have this option as of [1]

Fixed https://github.com/riscv/meta-riscv/issues/487#issuecomment-2626792694

[1] https://github.com/milkv-duo/duo-buildroot-sdk/blob/develop/fsbl/plat/cv181x/fiptool.py


