### PR TITLE
Add NAND support for Milk-V Duo

### DIFF
--- a/kas/milkv-duo.yml
+++ b/kas/milkv-duo.yml
@@ -4,3 +4,11 @@ header:
     - base-riscv.yml
 
 machine: milkv-duo 
+target: core-image-base
+
+repos:
+  meta-riscv:
+    url: https://github.com/riscv/meta-riscv.git
+    branch: master
+    layers:
+      - meta-riscv

--- a/recipes-bsp/milkv-duo-bootfiles/milkv-duo-bootfiles.bb
+++ b/recipes-bsp/milkv-duo-bootfiles/milkv-duo-bootfiles.bb
@@ -10,7 +10,6 @@ SRC_URI = "https://github.com/xyq1113723547/milkv-duo-bootfiles/raw/main/fip.bin
 SRC_URI[sha256sum] = "19670afc7c5361fbe81d61f843fe1df633f4ac77bf178c5421c76ddf314047a2"
 
 do_deploy() {
-        cp ${WORKDIR}/fip.bin ${DEPLOYDIR}/
 }
 
 addtask deploy after do_compile

--- a/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
+++ b/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
@@ -39,8 +39,12 @@ do_compile () {
 		--BLCP_2ND_RUNADDR=0x83f40000 \
 		--DDR_PARAM=${S}/test/cv181x/ddr_param.bin \
 		--MONITOR=${DEPLOY_DIR_IMAGE}/fw_dynamic.bin \
-		--LOADER_2ND=${DEPLOY_DIR_IMAGE}/u-boot.bin \
-		--NAND_BOOT=1
+		--LOADER_2ND=${DEPLOY_DIR_IMAGE}/u-boot.bin
+
+	# generate rootfs.spinand, boot.spinand, and system.spinand
+	python3 ${S}/common_tools/spinand_tool/mkubiimg.py --ubionly ${S}/common_tools/spinand_tool/flash_partition.xml ROOTFS ${DEPLOY_DIR_IMAGE}/rootfs.sqsh ${DEPLOY_DIR_IMAGE}/rootfs.spinand -b 0x20000 -p 0x800
+	python3 ${S}/common_tools/spinand_tool/mkubiimg.py --ubionly ${S}/common_tools/spinand_tool/flash_partition.xml BOOT ${DEPLOY_DIR_IMAGE}/boot.sqsh ${DEPLOY_DIR_IMAGE}/boot.spinand -b 0x20000 -p 0x800
+	python3 ${S}/common_tools/spinand_tool/mkubiimg.py --ubionly ${S}/common_tools/spinand_tool/flash_partition.xml SYSTEM ${DEPLOY_DIR_IMAGE}/system.sqsh ${DEPLOY_DIR_IMAGE}/system.spinand -b 0x20000 -p 0x800
 }
 
 do_deploy () {

--- a/wic/milkv-duo-spinand.wks
+++ b/wic/milkv-duo-spinand.wks
@@ -4,3 +4,8 @@ part /boot --source bootimg-partition --ondisk nand0 --fstype=vfat --label boot 
 part / --source rootfs --ondisk nand0 --fstype=ext4 --label root --align 4096 --size 128M
 part /system --source rootfs --ondisk nand0 --fstype=ext4 --label system --align 4096 --size 256M
 part /data --source rootfs --ondisk nand0 --fstype=ext4 --label data --align 4096 --size 512M
+
+# Generate rootfs.spinand, boot.spinand, and system.spinand files
+part /rootfs.spinand --source rawcopy --sourceparams="file=rootfs.spinand" --ondisk nand0 --fstype=ext4 --label rootfs --align 4096 --size 128M
+part /boot.spinand --source rawcopy --sourceparams="file=boot.spinand" --ondisk nand0 --fstype=ext4 --label boot --align 4096 --size 64M
+part /system.spinand --source rawcopy --sourceparams="file=system.spinand" --ondisk nand0 --fstype=ext4 --label system --align 4096 --size 256M


### PR DESCRIPTION
Related to #487

Add support for creating NAND image for Milk-V Duo in Yocto layer.

* **Remove non-existing argument**: Remove the `--NAND_BOOT=1` argument from `recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb`.
* **Generate required files**: Update `recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb` to generate `rootfs.spinand`, `boot.spinand`, and `system.spinand` files using `mkubiimg.py`.
* **Avoid file conflicts**: Remove the line `cp ${WORKDIR}/fip.bin ${DEPLOYDIR}/` from `recipes-bsp/milkv-duo-bootfiles/milkv-duo-bootfiles.bb` to avoid conflicts.
* **Update partition layout**: Add steps to generate `rootfs.spinand`, `boot.spinand`, and `system.spinand` files in `wic/milkv-duo-spinand.wks`.
* **Include necessary steps**: Update `kas/milkv-duo.yml` to include necessary steps for creating a NAND image.

