### PR TITLE
Replace obsolete `debug-tweaks` with explicit feature list

### DIFF
--- a/kas/include/local.yml
+++ b/kas/include/local.yml
@@ -4,7 +4,11 @@ header:
 local_conf_header:
   default: |
     # -- Default local.conf from meta-poky/conf/local.conf.sample -- #
-    EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+    EXTRA_IMAGE_FEATURES ?= "\
+        allow-empty-password \
+        empty-root-password \
+        allow-root-login \
+        post-install-logging"
     USER_CLASSES ?= "buildstats"
     PATCHRESOLVE = "noop"
     BB_DISKMON_DIRS ??= "\

--- a/kas/nezha.yml
+++ b/kas/nezha.yml
@@ -15,5 +15,8 @@ local_conf_header:
 
     IMAGE_FEATURES += " \
         ssh-server-openssh \
-        debug-tweaks \
+        allow-empty-password \
+        allow-root-login \
+        empty-root-password \
+        post-install-logging \
     "


### PR DESCRIPTION
Some time ago poky completely dropped "debug-tweaks" from features list [1]. As a result, the latest master can't be built because it tries to enable "debug-tweaks".
To avoid this issue, replace "debug-tweaks" with explicit features as done in Poky.

1 - https://git.yoctoproject.org/poky/commit/?id=43b8b3fa72d75d8d82a478613a4d9bf4645b5389

