### PR TITLE
[Styhead][U-Boot][AllWinnerD1] Fix folder for boot.scr.uimg

### DIFF
--- a/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
+++ b/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
@@ -29,7 +29,7 @@ do_compile[depends] = "opensbi:do_deploy"
 do_configure:prepend() {
     sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${UNPACKDIR}/tftp-mmc-boot.txt
     mkimage -O linux -T script -C none -n "U-Boot boot script" \
-        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${UNPACKDIR}/${UBOOT_ENV_BINARY}
+        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${B}/${UBOOT_ENV_BINARY}
 }
 
 do_compile:prepend() {


### PR DESCRIPTION
On the `Styhead` branch, during `u-boot-allwinnerd1`'s configure task, the file `boot.scr.uimg` gets installed in the `sources-unpack/` folder while the install/deploy tasks expect it in the `build/` folder, thus the build fails

This MR fixes the configure role to generate this file in the `build/` folder.

Tested generating both `mangopi-mq-pro` and `nezha` images that previously failed.

Attached full boot log on a mangopi-mq-pro:
[mangopi-mq-pro_fullboot_styhead.log](https://github.com/user-attachments/files/19639346/mangopi-mq-pro_fullboot_styhead.log)

Same fix might also be required on some other machines.
