### PR TITLE
linux-beaglev-dev: fix kernel do_patch

### DIFF
--- a/recipes-kernel/linux/linux-beaglev-dev/0003-dt-bindings-reset-Add-T-HEAD-TH1520-SoC-Reset-Contro.patch
+++ b/recipes-kernel/linux/linux-beaglev-dev/0003-dt-bindings-reset-Add-T-HEAD-TH1520-SoC-Reset-Contro.patch
@@ -1,6 +1,6 @@
-From a22ea13858b37b0f02aa4c42ea45a521a9417c27 Mon Sep 17 00:00:00 2001
-From: Kanak Shilledar <kanakshilledar111@protonmail.com>
-Date: Sun, 16 Mar 2025 13:38:38 +0530
+From 445607bf2114e75820f8a2d89643b873e49795e8 Mon Sep 17 00:00:00 2001
+From: RP38 <88386644+RP38@users.noreply.github.com>
+Date: Wed, 9 Apr 2025 13:13:38 +0200
 Subject: [PATCH 3/4] dt-bindings: reset: Add T-HEAD TH1520 SoC Reset
  Controller
 
@@ -71,20 +71,21 @@ index 000000000000..f2e91d0add7a
 +      };
 +    };
 diff --git a/MAINTAINERS b/MAINTAINERS
-index c9763412a508..d3b9be9e7b50 100644
+index 96b827049501..41667c7d94cb 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -20448,12 +20448,14 @@ F:	Documentation/devicetree/bindings/clock/thead,th1520-clk-ap.yaml
+@@ -20825,6 +20825,7 @@ F:	Documentation/devicetree/bindings/firmware/thead,th1520-aon.yaml
  F:	Documentation/devicetree/bindings/mailbox/thead,th1520-mbox.yaml
  F:	Documentation/devicetree/bindings/net/thead,th1520-gmac.yaml
  F:	Documentation/devicetree/bindings/pinctrl/thead,th1520-pinctrl.yaml
 +F:	Documentation/devicetree/bindings/reset/thead,th1520-reset.yaml
  F:	arch/riscv/boot/dts/thead/
  F:	drivers/clk/thead/clk-th1520-ap.c
- F:	drivers/mailbox/mailbox-th1520.c
- F:	drivers/net/ethernet/stmicro/stmmac/dwmac-thead.c
- F:	drivers/pinctrl/pinctrl-th1520.c
+ F:	drivers/firmware/thead,th1520-aon.c
+@@ -20835,6 +20836,7 @@ F:	drivers/pmdomain/thead/
  F:	include/dt-bindings/clock/thead,th1520-clk-ap.h
+ F:	include/dt-bindings/power/thead,th1520-power.h
+ F:	include/linux/firmware/thead/thead,th1520-aon.h
 +F:	include/dt-bindings/reset/thead,th1520-reset.h
  
  RNBD BLOCK DRIVERS

--- a/recipes-kernel/linux/linux-beaglev-dev/0004-reset-thead-Add-TH1520-reset-controller-driver.patch
+++ b/recipes-kernel/linux/linux-beaglev-dev/0004-reset-thead-Add-TH1520-reset-controller-driver.patch
@@ -1,6 +1,6 @@
-From d0edf7f81d6ad43ed54484a7d855ef9b66d7353c Mon Sep 17 00:00:00 2001
-From: Kanak Shilledar <kanakshilledar111@protonmail.com>
-Date: Sun, 16 Mar 2025 13:40:00 +0530
+From 0e6c191d0ce6ed5e38babd16c7e5b1c4cfe39c47 Mon Sep 17 00:00:00 2001
+From: RP38 <88386644+RP38@users.noreply.github.com>
+Date: Wed, 9 Apr 2025 13:14:47 +0200
 Subject: [PATCH 4/4] reset: thead: Add TH1520 reset controller driver
 
 Add reset controller driver for the T-HEAD TH1520 SoC that manages
@@ -21,22 +21,22 @@ Signed-off-by: Kanak Shilledar <kanakshilledar111@protonmail.com>
  create mode 100644 drivers/reset/reset-th1520.c
 
 diff --git a/MAINTAINERS b/MAINTAINERS
-index d3b9be9e7b50..13473f124876 100644
+index 41667c7d94cb..c86a33548e80 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -20454,6 +20454,7 @@ F:	drivers/clk/thead/clk-th1520-ap.c
- F:	drivers/mailbox/mailbox-th1520.c
+@@ -20833,6 +20833,7 @@ F:	drivers/mailbox/mailbox-th1520.c
  F:	drivers/net/ethernet/stmicro/stmmac/dwmac-thead.c
  F:	drivers/pinctrl/pinctrl-th1520.c
+ F:	drivers/pmdomain/thead/
 +F:	drivers/reset/reset-th1520.c
  F:	include/dt-bindings/clock/thead,th1520-clk-ap.h
- F:	include/dt-bindings/reset/thead,th1520-reset.h
- 
+ F:	include/dt-bindings/power/thead,th1520-power.h
+ F:	include/linux/firmware/thead/thead,th1520-aon.h
 diff --git a/drivers/reset/Kconfig b/drivers/reset/Kconfig
-index 5b3abb6db248..fa0943c3d1de 100644
+index 99f6f9784e68..11ce86c8156b 100644
 --- a/drivers/reset/Kconfig
 +++ b/drivers/reset/Kconfig
-@@ -272,6 +272,16 @@ config RESET_SUNXI
+@@ -279,6 +279,16 @@ config RESET_SUNXI
  	help
  	  This enables the reset driver for Allwinner SoCs.
  
@@ -54,10 +54,10 @@ index 5b3abb6db248..fa0943c3d1de 100644
  	tristate "TI System Control Interface (TI-SCI) reset driver"
  	depends on TI_SCI_PROTOCOL || (COMPILE_TEST && TI_SCI_PROTOCOL=n)
 diff --git a/drivers/reset/Makefile b/drivers/reset/Makefile
-index 677c4d1e2632..d6c2774407ae 100644
+index 31f9904d13f9..6322a191e2a8 100644
 --- a/drivers/reset/Makefile
 +++ b/drivers/reset/Makefile
-@@ -35,6 +35,7 @@ obj-$(CONFIG_RESET_SIMPLE) += reset-simple.o
+@@ -36,6 +36,7 @@ obj-$(CONFIG_RESET_SIMPLE) += reset-simple.o
  obj-$(CONFIG_RESET_SOCFPGA) += reset-socfpga.o
  obj-$(CONFIG_RESET_SUNPLUS) += reset-sunplus.o
  obj-$(CONFIG_RESET_SUNXI) += reset-sunxi.o


### PR DESCRIPTION
linux-beaglev-dev recipe was failing at the patching step due to outdated patches, refined the patches
required for kernel to boot.

fixes #519

