### PR TITLE
[U-Boot][AllWinnerD1] Fix build of u-boot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
+++ b/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
@@ -12,6 +12,7 @@ SRC_URI = " \
     file://tftp-mmc-boot.txt \
     file://uEnv-nezha.txt \
     file://0001-sun20i-set-CONFIG_SYS_BOOTM_LEN.patch \
+    file://0002-Fix-build-with-newer-swig.patch \
 "
 SRCREV = "2e89b706f5c956a70c989cd31665f1429e9a0b48"
 

--- a/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
+++ b/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
@@ -30,7 +30,7 @@ do_compile[depends] = "opensbi:do_deploy"
 do_configure:prepend() {
     sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${UNPACKDIR}/tftp-mmc-boot.txt
     mkimage -O linux -T script -C none -n "U-Boot boot script" \
-        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${UNPACKDIR}/${UBOOT_ENV_BINARY}
+        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${B}/${UBOOT_ENV_BINARY}
 }
 
 do_compile:prepend() {

--- a/recipes-bsp/u-boot/u-boot-allwinnerd1/0002-Fix-build-with-newer-swig.patch
+++ b/recipes-bsp/u-boot/u-boot-allwinnerd1/0002-Fix-build-with-newer-swig.patch
@@ -1,0 +1,61 @@
+Backport of exiting patch on official u-boot. Not present on the fork yet.
+
+Upstream-Status: Pending on u-boot fork used in this layer.
+Upstream-Status: Backport of official u-boot commit a63456b9191fae2fe49f4b121e025792022e3950
+
+From a63456b9191fae2fe49f4b121e025792022e3950 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Wed, 30 Oct 2024 06:07:16 +0100
+Subject: [PATCH] scripts/dtc/pylibfdt/libfdt.i_shipped: Use SWIG_AppendOutput
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Swig has changed language specific AppendOutput functions. The helper
+macro SWIG_AppendOutput remains unchanged. Use that instead
+of SWIG_Python_AppendOutput, which would require an extra parameter
+since swig 4.3.0.
+
+/home/flk/poky/build-test/tmp/work/qemux86_64-poky-linux/u-boot/2024.10/git/arch/x86/cpu/u-boot-64.lds
+| scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_next_node’:
+| scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
+|  5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
+|       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Link: https://github.com/dgibson/dtc/pull/154
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/dtc/pylibfdt/libfdt.i_shipped b/scripts/dtc/pylibfdt/libfdt.i_shipped
+index 56cc5d48f4f..e4659489a96 100644
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+ 
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+ 
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+ 
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }


### PR DESCRIPTION
During u-boot-allwinnerd1's configure task, the file boot.scr.uimg gets installed in the sources-unpack/ folder while the install/deploy tasks expect it in the build/ folder.

In addition the newer Python version is not compatible anymore with this u-boot version. I added a patch back ported from upstream u-boot that fixes this.

I will try to open a MR with this back ported patch to the u-boot fork used for AllWinner D1. Doesn't seem to be actively maintained, still worth a try

Tested generating and running on a mangopi-mq-pro, both against poki's master and walnascar branches.

Attached full boot log on a mangopi-mq-pro:
[mangopi-mq-pro_fullboot_master.log](https://github.com/user-attachments/files/19702327/mangopi-mq-pro_fullboot_master.log)

I'm still learning Yocto, so not sure about the formatting of the patch file. I tried to follow https://docs.yoctoproject.org/contributor-guide/recipe-style-guide.html#patch-upstream-status and put both `Upstream-Status` info for the u-boot fork and the official one.