### PR TITLE
beaglev-ahead: sdcard wic image generation

### DIFF
--- a/conf/machine/beaglev-ahead.conf
+++ b/conf/machine/beaglev-ahead.conf
@@ -27,7 +27,8 @@ UBOOT_DTB_BINARY = "th1520-beaglev-ahead.dtb"
 # Image Configuration
 # Note: currently just a fastboot deployment is supported
 #       for which a separate boot.ext4 is generated
-#IMAGE_BOOT_FILES:append = "fw_payload.bin"
+IMAGE_BOOT_FILES:remove = "boot.scr.uimg"
+IMAGE_BOOT_FILES:append = "fw_payload.bin th1520-beaglev-ahead.dtb extlinux_sd.conf;extlinux/extlinux.conf"
 WKS_FILE ?= "beaglev-ahead.wks"
 #============================================
 

--- a/recipes-kernel/linux/linux-beaglev-dev.bb
+++ b/recipes-kernel/linux/linux-beaglev-dev.bb
@@ -56,6 +56,9 @@ do_deploy:append() {
     cp -f ${DEPLOYDIR}/th1520-beaglev-ahead.dtb ${DEPLOY_DIR_IMAGE}/.boot/
     cp -f ${DEPLOYDIR}/Image ${DEPLOY_DIR_IMAGE}/.boot/
     cp -f ${UNPACKDIR}/extlinux.conf ${DEPLOY_DIR_IMAGE}/.boot/extlinux/
+    
+    cp -f ${UNPACKDIR}/extlinux.conf ${DEPLOY_DIR_IMAGE}/extlinux_sd.conf
+    sed -i 's/\/dev\/mmcblk0p3/\/dev\/mmcblk1p3/g' ${DEPLOY_DIR_IMAGE}/extlinux_sd.conf
 
     dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/boot.ext4 bs=1 count=0 seek=190M
     mkfs.ext4 -F ${DEPLOY_DIR_IMAGE}/boot.ext4 -d ${DEPLOY_DIR_IMAGE}/.boot

--- a/wic/beaglev-ahead.wks
+++ b/wic/beaglev-ahead.wks
@@ -1,4 +1,5 @@
-# short-description: Create SD card image for BeagleV-ahead: NOTE this does not boot yet via SD
-
-#part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --size=100M --align 4096
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 4096 --size 1G
+# short-description: Create SD card image for BeagleV-ahead
+bootloader --ptable gpt
+part                                                --label empty --part-name empty --align 4096 --size=2M 
+part /boot --source bootimg-partition --fstype=ext4 --label boot  --part-name boot  --align 4096 --size=100M
+part /     --source rootfs            --fstype=ext4 --label root  --part-name root  --align 4096 --size 1G


### PR DESCRIPTION
This PR brings support for sdcard images for beaglev ahead.

- Completed wks file to generate required partition for beaglev-ahead boot.
- Added extlinux_sd.conf which target root partition on the sdcard instead of eMMC.
- appended IMAGE_BOOT_FILES to identify required files in the boot partition.

(currently in draft because of issue #526)

