### PR TITLE
Adapt to UNPACKDIR changes

### DIFF
--- a/recipes-bsp/firmware/firmware-rcpu-orangepi-rv2.bb
+++ b/recipes-bsp/firmware/firmware-rcpu-orangepi-rv2.bb
@@ -5,8 +5,7 @@ LICENSE = "CLOSED"
 
 SRC_URI = "file://esos.elf"
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 do_install() {
     install -d ${D}/lib/firmware

--- a/recipes-bsp/jh7110-spl-tool/jh7110-spl-tool_git.bb
+++ b/recipes-bsp/jh7110-spl-tool/jh7110-spl-tool_git.bb
@@ -6,7 +6,7 @@ SECTION = "bootloaders"
 SRCREV = "0747c0510e090f69bf7d2884f44903b77b3db5c5"
 SRC_URI = "git://github.com/starfive-tech/Tools;protocol=https;branch=master"
 
-S = "${WORKDIR}/git/spl_tool"
+S = "${UNPACKDIR}/${BP}/spl_tool"
 
 do_compile () {
     cd ${S}

--- a/recipes-bsp/milkv-duo-bootfiles/milkv-duo-bootfiles.bb
+++ b/recipes-bsp/milkv-duo-bootfiles/milkv-duo-bootfiles.bb
@@ -10,7 +10,7 @@ SRC_URI = "https://github.com/xyq1113723547/milkv-duo-bootfiles/raw/main/fip.bin
 SRC_URI[sha256sum] = "19670afc7c5361fbe81d61f843fe1df633f4ac77bf178c5421c76ddf314047a2"
 
 do_deploy() {
-        cp ${WORKDIR}/fip.bin ${DEPLOYDIR}/
+        cp ${UNPACKDIR}/fip.bin ${DEPLOYDIR}/
 }
 
 addtask deploy after do_compile

--- a/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
+++ b/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
@@ -8,7 +8,7 @@ SRCREV = "f359994bd497f942bb67734280d81f6640c7c168"
 
 COMPATIBLE_MACHINE = "milkv-duo"
 
-S = "${WORKDIR}/git/firmware"
+S = "${UNPACKDIR}/${BP}/firmware"
 B = "${S}/build"
 
 TARGET_LDFLAGS = ""

--- a/recipes-bsp/opensbi/opensbi_%.bbappend
+++ b/recipes-bsp/opensbi/opensbi_%.bbappend
@@ -19,7 +19,7 @@ SRC_URI:milkv-duo = "git://github.com/riscv-software-src/opensbi.git;branch=mast
 SRC_URI:c910 = "git://github.com/revyos/thead-opensbi.git;branch=th1520;protocol=https"
 SRC_URI:orangepi-rv2 = "git://github.com/orangepi-xunlong/u-boot-orangepi.git;protocol=https;branch=${BRANCH}"
 SRC_URI:append:orangepi-rv2 = " file://c23-compatibility.patch"
-S:orangepi-rv2 = "${WORKDIR}/git/opensbi"
+S:orangepi-rv2 = "${UNPACKDIR}/${BP}/opensbi"
 
 DEPENDS:append:jh7110 = " u-boot-tools-native dtc-native"
 DEPENDS:append:orangepi-rv2 = " u-boot-tools-native"

--- a/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
+++ b/recipes-bsp/u-boot/u-boot-allwinnerd1.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-
 SRC_URI = " \
     git://github.com/smaeul/u-boot.git;protocol=https;branch=d1-wip \
     file://tftp-mmc-boot.txt \
@@ -20,7 +19,6 @@ DEPENDS:append = " \
     u-boot-tools-native \
     python3-setuptools-native \
 "
-
 
 # Overwrite this for your server
 TFTP_SERVER_IP ?= "127.0.0.1"

--- a/recipes-bsp/u-boot/u-boot-beaglev-ahead.bb
+++ b/recipes-bsp/u-boot/u-boot-beaglev-ahead.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-
 SRC_URI = " \
     git://github.com/beagleboard/beaglev-ahead-u-boot.git;protocol=https;branch=beaglev-v2020.01-1.1.2-ubuntu \
     file://0001-Set-sec_library-path-to-source-location.patch \

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
@@ -35,7 +35,7 @@ TFTP_SERVER_IP ?= "127.0.0.1"
 do_configure:prepend() {
     sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${UNPACKDIR}/tftp-mmc-boot.txt
     mkimage -O linux -T script -C none -n "U-Boot boot script" \
-        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
+        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${UNPACKDIR}/${UBOOT_ENV_BINARY}
 }
 
 do_deploy:append:visionfive() {
@@ -49,6 +49,3 @@ do_deploy:append:visionfive2() {
 COMPATIBLE_MACHINE = "(visionfive|visionfive2)"
 
 TOOLCHAIN = "gcc"
-
-# U-boot sets O=... which needs it to build outside of S
-B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.07.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.07.bb
@@ -22,12 +22,9 @@ TFTP_SERVER_IP ?= "127.0.0.1"
 do_configure:prepend() {
     sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${UNPACKDIR}/tftp-mmc-boot.txt
     mkimage -O linux -T script -C none -n "U-Boot boot script" \
-        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${WORKDIR}/${UBOOT_ENV_BINARY}
+        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${UNPACKDIR}/${UBOOT_ENV_BINARY}
 }
 
 COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100)"
 
 TOOLCHAIN = "gcc"
-
-# U-boot sets O=... which needs it to build outside of S
-B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -40,7 +40,3 @@ do_deploy:append() {
 COMPATIBLE_MACHINE = "star64"
 
 TOOLCHAIN = "gcc"
-
-
-# U-boot sets O=... which needs it to build outside of S
-B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -36,7 +36,6 @@ do_deploy:append() {
     ln -sf ${SPL_IMAGE}.normal.out ${DEPLOYDIR}/${SPL_SYMLINK}.normal.out
 }
 
-
 COMPATIBLE_MACHINE = "star64"
 
 TOOLCHAIN = "gcc"

--- a/recipes-devtools/riscv-tools/riscv-fesvr.bb
+++ b/recipes-devtools/riscv-tools/riscv-fesvr.bb
@@ -12,7 +12,6 @@ inherit autotools gettext cross-canadian
 
 BBCLASSEXTEND = "native nativesdk"
 
-
 do_configure:prepend () {
         if [ ! -e ${S}/acinclude.m4 ]; then
                 cp ${S}/aclocal.m4 ${S}/acinclude.m4

--- a/recipes-devtools/riscv-tools/riscv-fesvr.bb
+++ b/recipes-devtools/riscv-tools/riscv-fesvr.bb
@@ -12,7 +12,6 @@ inherit autotools gettext cross-canadian
 
 BBCLASSEXTEND = "native nativesdk"
 
-S = "${WORKDIR}/git"
 
 do_configure:prepend () {
         if [ ! -e ${S}/acinclude.m4 ]; then

--- a/recipes-devtools/riscv-tools/riscv-spike.bb
+++ b/recipes-devtools/riscv-tools/riscv-spike.bb
@@ -13,7 +13,6 @@ RDEPENDS:nativesdk-riscv-spike = "nativesdk-riscv-fesvr"
 
 inherit autotools cross-canadian
 
-
 do_configure:prepend () {
 	touch ${S}/softfloat/softfloat.ac
         if [ ! -e ${S}/acinclude.m4 ]; then

--- a/recipes-devtools/riscv-tools/riscv-spike.bb
+++ b/recipes-devtools/riscv-tools/riscv-spike.bb
@@ -13,7 +13,6 @@ RDEPENDS:nativesdk-riscv-spike = "nativesdk-riscv-fesvr"
 
 inherit autotools cross-canadian
 
-S = "${WORKDIR}/git"
 
 do_configure:prepend () {
 	touch ${S}/softfloat/softfloat.ac

--- a/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
+++ b/recipes-graphics/drivers/visionfive2-pvr-graphics_1.19.bb
@@ -13,7 +13,6 @@ DEPENDS:append:libc-musl = " gcompat patchelf-native"
 SRC_URI += "\
         file://glesv1_cm.pc \
 "
-S = "${WORKDIR}/git"
 
 PACKAGES += " \
     ${PN}-firmware \

--- a/recipes-graphics/mesa/mesa-pvr.inc
+++ b/recipes-graphics/mesa/mesa-pvr.inc
@@ -80,7 +80,7 @@ SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${PV}.tar.xz \
         file://0062-gallium-pvr-support-DRI-Image-extension-v21.patch \
            "
 
-S = "${WORKDIR}/mesa-${PV}"
+S = "${UNPACKDIR}/mesa-${PV}"
 
 SRC_URI[sha256sum] = "b98f32ba7aa2a1ff5725fb36eb999c693079f0ca16f70aa2f103e2b6c3f093e3"
 

--- a/recipes-kernel/firmware/linux-firmware-beaglev-bcm43430.bb
+++ b/recipes-kernel/firmware/linux-firmware-beaglev-bcm43430.bb
@@ -25,8 +25,7 @@ SRC_URI[brcmfmac43430-clm.sha256sum] = "3ce2e8884dbd37d63ca8bae07bf7ea17c110070f
 SRC_URI[AP6212.sha256sum] = "fdef0603345dd023ad28c0eff2d5167915c617bee2d6944da9a6da1c4ac87ca5"
 SRC_URI[license.sha256sum] = "b16056fc91b82a0e3e8de8f86c2dac98201aa9dc3cbd33e8d38f1b087fcec30d"
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 inherit allarch
 

--- a/recipes-kernel/firmware/linux-firmware-orangepi.bb
+++ b/recipes-kernel/firmware/linux-firmware-orangepi.bb
@@ -7,7 +7,6 @@ inherit allarch
 SRC_URI = "git://github.com/orangepi-xunlong/firmware.git;protocol=https;branch=master"
 SRCREV = "db5e86200ae592c467c4cfa50ec0c66cbc40b158"
 
-
 do_install:orangepi-rv2() {
 	install -d ${D}${nonarch_base_libdir}/firmware
 	install -d ${D}${nonarch_base_libdir}/firmware/brcm

--- a/recipes-kernel/firmware/linux-firmware-orangepi.bb
+++ b/recipes-kernel/firmware/linux-firmware-orangepi.bb
@@ -7,7 +7,6 @@ inherit allarch
 SRC_URI = "git://github.com/orangepi-xunlong/firmware.git;protocol=https;branch=master"
 SRCREV = "db5e86200ae592c467c4cfa50ec0c66cbc40b158"
 
-S = "${WORKDIR}/git"
 
 do_install:orangepi-rv2() {
 	install -d ${D}${nonarch_base_libdir}/firmware

--- a/recipes-kernel/firmware/linux-firmware-visionfive2-imggpu.bb
+++ b/recipes-kernel/firmware/linux-firmware-visionfive2-imggpu.bb
@@ -5,7 +5,6 @@ LICENSE = "CLOSED"
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit allarch
 
-
 CLEANBROKEN = "1"
 
 do_install () {

--- a/recipes-kernel/firmware/linux-firmware-visionfive2-imggpu.bb
+++ b/recipes-kernel/firmware/linux-firmware-visionfive2-imggpu.bb
@@ -5,7 +5,6 @@ LICENSE = "CLOSED"
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit allarch
 
-S = "${WORKDIR}/git"
 
 CLEANBROKEN = "1"
 

--- a/recipes-kernel/firmware/linux-firmware-visionfive2-wave420l.bb
+++ b/recipes-kernel/firmware/linux-firmware-visionfive2-wave420l.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
 require recipes-bsp/common/visionfive2-firmware.inc
 inherit allarch
 
-S = "${WORKDIR}/git/wave420l"
+S = "${UNPACKDIR}/${BP}/wave420l"
 
 CLEANBROKEN = "1"
 

--- a/recipes-kernel/firmware/linux-firmware-visionfive2-wave511.bb
+++ b/recipes-kernel/firmware/linux-firmware-visionfive2-wave511.bb
@@ -11,7 +11,7 @@ SRC_URI += " \
     "
 SRC_URI[wave511_dec_fw.sha256sum] = "398eb201cf4d6c5050856de5660764a743b8879a69b8684d12aadb556409b79c"
 
-S = "${WORKDIR}/git/wave511/firmware"
+S = "${UNPACKDIR}/${BP}/wave511/firmware"
 
 CLEANBROKEN = "1"
 

--- a/recipes-kernel/linux/linux-allwinnerd1-dev.bb
+++ b/recipes-kernel/linux/linux-allwinnerd1-dev.bb
@@ -34,6 +34,5 @@ COMPATIBLE_MACHINE = "(nezha-allwinner-d1|mangopi-mq-pro)"
 LINUX_VERSION_EXTENSION:append:nezha-allwinner-d1 = "-nezha"
 LINUX_VERSION_EXTENSION:append:mangopi-mq-pro = "-mangopi"
 
-
 ## Should be oveerriten in machine conf
 KBUILD_DEFCONFIG ?= "allwinner_defconfig"

--- a/recipes-kernel/modules/jpu-module.bb
+++ b/recipes-kernel/modules/jpu-module.bb
@@ -6,15 +6,13 @@ LIC_FILES_CHKSUM = "file://../../../LICENSE.txt;md5=16bead7cc56b053f5da0061ce063
 
 COMPATIBLE_MACHINE = "jh7110"
 
-JPU_MODULE_SRC = "git/codaj12/jdi/linux/driver"
-
 inherit module
 require recipes-bsp/common/visionfive2-firmware.inc
 
 SRC_URI += " \
-    file://Makefile;subdir=${JPU_MODULE_SRC} \
+    file://Makefile;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/codaj12/jdi/linux/driver \
 "
 
-S = "${WORKDIR}/${JPU_MODULE_SRC}"
+S = "${UNPACKDIR}/${BP}/codaj12/jdi/linux/driver"
 
 RPROVIDES:${PN} += "kernel-module-jpu"

--- a/recipes-kernel/modules/vdec-module.bb
+++ b/recipes-kernel/modules/vdec-module.bb
@@ -7,16 +7,14 @@ LIC_FILES_CHKSUM = "file://../../../LICENSE.txt;md5=16bead7cc56b053f5da0061ce063
 
 COMPATIBLE_MACHINE = "jh7110"
 
-WAVE511_MODULE_SRC = "git/wave511/code/vdi/linux/driver"
-
 inherit module
 require recipes-bsp/common/visionfive2-firmware.inc
 
 SRC_URI += " \
-    file://Makefile;subdir=${WAVE511_MODULE_SRC} \
+    file://Makefile;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/wave511/code/vdi/linux/driver \
 "
 
-S = "${WORKDIR}/${WAVE511_MODULE_SRC}"
+S = "${UNPACKDIR}/${BP}/wave511/code/vdi/linux/driver"
 
 RPROVIDES:${PN} += "kernel-module-vdec"
 RDEPENDS:${PN} += "linux-firmware-visionfive2-wave511"

--- a/recipes-kernel/modules/venc-module.bb
+++ b/recipes-kernel/modules/venc-module.bb
@@ -7,16 +7,14 @@ LIC_FILES_CHKSUM = "file://../../../LICENSE.txt;md5=16bead7cc56b053f5da0061ce063
 
 COMPATIBLE_MACHINE = "jh7110"
 
-WAVE420L_MODULE_SRC = "git/wave420l/code/vdi/linux/driver"
-
 inherit module
 require recipes-bsp/common/visionfive2-firmware.inc
 
 SRC_URI += " \
-    file://Makefile;subdir=${WAVE420L_MODULE_SRC} \
+    file://Makefile;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/wave420l/code/vdi/linux/driver \
 "
 
-S = "${WORKDIR}/${WAVE420L_MODULE_SRC}"
+S = "${UNPACKDIR}/${BP}/wave420l/code/vdi/linux/driver"
 
 RPROVIDES:${PN} += "kernel-module-venc"
 RDEPENDS:${PN} += "linux-firmware-visionfive2-wave420l"

--- a/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
+++ b/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
@@ -13,7 +13,6 @@ SRC_URI = " \
           git://github.com/lwfinger/rtl8723ds.git;protocol=https;name=rtl8723ds;branch=master \
           file://0001-Makefile-Add-modules_install-chain-and-make-KSRC-ass.patch  \
 	  "
-S = "${WORKDIR}/git"
 
 RPROVIDES:${PN} += "kernel-module-rtl8723ds"
 

--- a/recipes-multimedia/vpu/libsf-codaj12.bb
+++ b/recipes-multimedia/vpu/libsf-codaj12.bb
@@ -13,11 +13,11 @@ SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 
 SRC_URI += " \
-    file://codaj12_yocto.mak;subdir=git/codaj12 \
+    file://codaj12_yocto.mak;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/codaj12 \
     file://20_jpu.rules \
 "
 
-S = "${WORKDIR}/git/codaj12"
+S = "${UNPACKDIR}/${BP}/codaj12"
 
 do_compile() {
     oe_runmake -C ${S} -f codaj12_yocto.mak

--- a/recipes-multimedia/vpu/libsf-codaj12.bb
+++ b/recipes-multimedia/vpu/libsf-codaj12.bb
@@ -46,7 +46,6 @@ do_install() {
     install -d ${D}/usr/lib
     install -m 0644 ${S}/libcodadec.so ${D}/usr/lib/
 
-
     install -d ${D}/${base_libdir}/udev/rules.d/
     install -m 0644 ${UNPACKDIR}/20_jpu.rules ${D}/${base_libdir}/udev/rules.d/
 }

--- a/recipes-multimedia/vpu/libsf-omxil.bb
+++ b/recipes-multimedia/vpu/libsf-omxil.bb
@@ -16,10 +16,10 @@ FILES_SOLIBSDEV = ""
 INSANE_SKIP:${PN} += "dev-so"
 
 SRC_URI += " \
-     file://CMakeLists.txt;subdir=git/omx-il \
+     file://CMakeLists.txt;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/omx-il \
 "
 
-S = "${WORKDIR}/git/omx-il"
+S = "${UNPACKDIR}/${BP}/omx-il"
 
 DEPENDS += " \
     libsf-wave420l \

--- a/recipes-multimedia/vpu/libsf-wave420l.bb
+++ b/recipes-multimedia/vpu/libsf-wave420l.bb
@@ -13,11 +13,11 @@ SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 
 SRC_URI += " \
-    file://WaveEncoder_yocto.mak;subdir=git/wave420l/code \
+    file://WaveEncoder_yocto.mak;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/wave420l/code \
     file://20_venc.rules \
 "
 
-S = "${WORKDIR}/git/wave420l/code"
+S = "${UNPACKDIR}/${BP}/wave420l/code"
 
 do_configure:prepend() {
     # workaround wrong build system/include path assumptions

--- a/recipes-multimedia/vpu/libsf-wave511.bb
+++ b/recipes-multimedia/vpu/libsf-wave511.bb
@@ -13,11 +13,11 @@ SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 
 SRC_URI += " \
-    file://WaveDecode_yocto.mak;subdir=git/wave511/code \
+    file://WaveDecode_yocto.mak;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/wave511/code \
     file://20_vdec.rules \
 "
 
-S = "${WORKDIR}/git/wave511/code"
+S = "${UNPACKDIR}/${BP}/wave511/code"
 
 do_configure:prepend() {
     # workaround wrong build system/include path assumptions


### PR DESCRIPTION
I tried to verified that bitbake -c patch world runs successfully with these changes but I couldn't. Because, these recipes:

- linux-firmware-visionfive2-wave511.bb
- linux-firmware-visionfive2-imggpu.bb
- linux-firmware-visionfive2-wave420l.bb

throwing error and it's not related to this changes. It seems to be related to a new "feature" GitHub rolled out which is affecting LFS -> https://github.com/orgs/community/discussions/151710#discussioncomment-12925457

That's why the above recipes are not fetchable right now. Also, looks like someone opened issue to upstream related to this -> https://github.com/starfive-tech/soft_3rdpart/issues/10

In addition, most recipes shouldn’t need further fixes.