### PR TITLE
linux-starfive-dev: Remove KERNEL_FEATURES_RISCV

### DIFF
--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -54,7 +54,7 @@ SRC_URI:beaglev-starlight-jh7100 = " \
            file://modules.cfg \
            file://extra.cfg \
 "
-SRCREV_yocto-kernel-cache = "99c5ec65d21cd824d26ee9eb8bca7d2e59311e5f"
+SRCREV_yocto-kernel-cache = "6df14e0eacedd9f025d88e310ef7fcc0bde6f550"
 
 SRC_URI:append:visionfive2 = " git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=yocto-kernel-cache;branch=yocto-6.6;destsuffix=kernel-meta;protocol=https"
 
@@ -67,5 +67,9 @@ KBUILD_DEFCONFIG:beaglev-starlight-jh7100 = "starfive_jh7100_fedora_defconfig"
 KBUILD_DEFCONFIG:visionfive = "visionfive_defconfig"
 KBUILD_DEFCONFIG:visionfive2 = "starfive_visionfive2_defconfig"
 KBUILD_DEFCONFIG:star64 = "pine64_star64_defconfig"
+
+KERNEL_FEATURES:remove:riscv32 = " ${KERNEL_FEATURES_RISCV}"
+KERNEL_FEATURES:remove:riscv64 = " ${KERNEL_FEATURES_RISCV}"
+
 
 COMPATIBLE_MACHINE = "(beaglev-starlight-jh7100|visionfive|jh7110)"


### PR DESCRIPTION
This kernel is 6.6 and upstream linux-yocto kernel cache has added KERNEL_FEATURES_RISCV kernel features to 6.12 branch onwards and has started using it in linux-yocto.inc which is used by this recipe

Remove these scc files until this kernel moves to 6.12+ and metadata branch is updated accordingly as well.

Upgrade yocto-kernel-cache/6.6 to latest tip while here.

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- <recipename>: Short log / Statement of what needed to be changed.**
  
**-(Optional pointers to external resources, such as defect tracking)**
  
**-The intent of your change.**
  
**-(Optional, if it's not clear from above) how your change resolves the
issues in the first part.**
  
**-Tag line(s) at the end.**

**-Signed-off-by: Random J Developer <random@developer.example.org>**

