### PR TITLE
visionfive2-firmware.inc: Specify revision using SRCREV

### DIFF
--- a/recipes-bsp/common/visionfive2-firmware.inc
+++ b/recipes-bsp/common/visionfive2-firmware.inc
@@ -1,6 +1,7 @@
 VISIONFIVE2FW_DATE ?= "20240826^"
 # JH7110_VF2_6.6_v5.13.1
-SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;nobranch=1;rev=4918bd0772edbfd9ccf26e97b55091f72053ec81"
+SRCREV = "4918bd0772edbfd9ccf26e97b55091f72053ec81"
+SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;nobranch=1"
 HOMEPAGE ?= "https://github.com/starfive-tech/soft_3rdpart"
 
 IMG_GPU_POWERVR_VERSION = "img-gpu-powervr-bin-1.19.6345021"


### PR DESCRIPTION
Do not encode it in rev= param in SRC_URI, this fails with lfs enabled

WARNING: linux-firmware-visionfive2-imggpu-1.0-r0 do_fetch: Fetching LFS did not succeed.

