### PR TITLE
visionfive2-firmware: Point to strlcat.eu mirror

### DIFF
--- a/recipes-bsp/common/visionfive2-firmware.inc
+++ b/recipes-bsp/common/visionfive2-firmware.inc
@@ -1,7 +1,8 @@
 VISIONFIVE2FW_DATE ?= "20240826^"
 # JH7110_VF2_6.6_v5.13.1
 SRCREV = "4918bd0772edbfd9ccf26e97b55091f72053ec81"
-SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;nobranch=1"
+#SRC_URI += "git://github.com/starfive-tech/soft_3rdpart.git;protocol=https;lfs=1;nobranch=1"
+SRC_URI += "git://strlcat.eu/mirroring/jh7110_soft_3rdpart.git;protocol=https;lfs=1;branch=JH7110_VisionFive2_devel"
 HOMEPAGE ?= "https://github.com/starfive-tech/soft_3rdpart"
 
 IMG_GPU_POWERVR_VERSION = "img-gpu-powervr-bin-1.19.6345021"


### PR DESCRIPTION
starfive repo is not able to allow LFS fetches

This repository exceeded its LFS budget. The account responsible for the budget should increase it to restore access.

Until it is fixed in github.com/starfive-tech/soft_3rdpart.git Use a mirror

https://forum.rvspace.org/t/quota-problem-for-github-com-starfive-tech-soft-3rdpart/4597?utm_source=chatgpt.com
