### PR TITLE
riscv-common.inc: update fit image class usage

### DIFF
--- a/conf/machine/include/riscv-common.inc
+++ b/conf/machine/include/riscv-common.inc
@@ -4,8 +4,7 @@ require conf/machine/include/riscv/tune-riscv.inc
 
 #============================================
 # Common Linux Kernel & Uboot Configuration
-KERNEL_CLASSES ?= "kernel-fitimage"
-KERNEL_IMAGETYPE ?= "fitImage"
+KERNEL_CLASSES ?= "kernel-fit-extra-artifacts"
 UBOOT_ENV ?= "boot"
 UBOOT_ENV_SUFFIX = "scr.uimg"
 #============================================


### PR DESCRIPTION
Use KERNEL_CLASSES ?= "kernel-fit-extra-artifacts" instead of KERNEL_CLASSES ?= "kernel-fitimage" and KERNEL_IMAGETYPE ?= "fitImage" in riscv-common.inc.

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>

