### PR TITLE
beaglev-ahead hotfix: replace deprecated kernel-fitimage

### DIFF
--- a/conf/machine/beaglev-ahead.conf
+++ b/conf/machine/beaglev-ahead.conf
@@ -13,6 +13,7 @@ unset RISCV_SBI_PAYLOAD
 
 #============================================
 # Kernel Configuration
+KERNEL_CLASSES = "kernel-fit-extra-artifacts"
 KERNEL_DEVICETREE ?= "thead/th1520-beaglev-ahead.dtb"
 KERNEL_IMAGETYPE = "Image"
 #============================================


### PR DESCRIPTION
kernel_classes "kernel-fitimage" is now deprecated, using now kernel-fit-extra-artifacts as a hotfix for the beaglev ahead only. A proper fix using kernel_classes "kernel-fit-image" might be pushed later.

fixes #541 

