### PR TITLE
grub-efi: add .bbappend for visionfive2

### DIFF
--- a/recipes-bsp/grub/grub-efi/0263-Use-medany-instead-of-large-model-for-RISCV.patch
+++ b/recipes-bsp/grub/grub-efi/0263-Use-medany-instead-of-large-model-for-RISCV.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Montleon <jason@montleon.com>
+Date: Fri, 3 May 2024 13:18:37 -0400
+Subject: [PATCH] Use medany instead of large model for RISCV
+
+Upstream-Status: Submitted [https://savannah.gnu.org/bugs/?65909]
+
+Signed-off-by: Jason Montleon <jason@montleon.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
+---
+ configure.ac | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index d223fe3ef6e..6a6688e362a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1313,7 +1313,7 @@ AC_SUBST(TARGET_LDFLAGS_OLDMAGIC)
+ 
+ LDFLAGS="$TARGET_LDFLAGS"
+ 
+-if test "$target_cpu" = x86_64 || test "$target_cpu" = sparc64 || test "$target_cpu" = riscv64 ; then
++if test "$target_cpu" = x86_64 || test "$target_cpu" = sparc64 ; then
+   # Use large model to support 4G memory
+   AC_CACHE_CHECK([whether option -mcmodel=large works], grub_cv_cc_mcmodel, [
+     CFLAGS="$TARGET_CFLAGS -mcmodel=large"
+@@ -1323,9 +1323,11 @@ if test "$target_cpu" = x86_64 || test "$target_cpu" = sparc64 || test "$target_
+   ])
+   if test "x$grub_cv_cc_mcmodel" = xyes; then
+     TARGET_CFLAGS="$TARGET_CFLAGS -mcmodel=large"
+-  elif test "$target_cpu" = sparc64 || test "$target_cpu" = riscv64; then
++  elif test "$target_cpu" = sparc64; then
+     TARGET_CFLAGS="$TARGET_CFLAGS -mcmodel=medany"
+   fi
++elif test "$target_cpu" = riscv64 ; then
++    TARGET_CFLAGS="$TARGET_CFLAGS -mcmodel=medany"
+ fi
+ 
+ if test "$target_cpu"-"$platform" = x86_64-efi; then

--- a/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:visionfive2 = " file://0263-Use-medany-instead-of-large-model-for-RISCV.patch"


### PR DESCRIPTION
Builds with newer gcc versions fail for the visionfive2 MACHINE target with the following error:

|grub-mkimage: error: relocation 0x2b is not implemented yet.

Add a patch to use medany instead of the large model for the target. This could apply to all builds, but only visionfive2 has thus far been tested.

See: https://savannah.gnu.org/bugs/?65909

