### PR TITLE
conf/machine/orangepi-rv2.conf: weak assignment for KERNEL_DEVICETREE

### DIFF
--- a/conf/machine/orangepi-rv2.conf
+++ b/conf/machine/orangepi-rv2.conf
@@ -8,7 +8,7 @@ require conf/machine/include/riscv/tune-riscv.inc
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-orangepi"
 
-KERNEL_DEVICETREE = "ky/x1_orangepi-rv2.dtb"
+KERNEL_DEVICETREE ?= "ky/x1_orangepi-rv2.dtb"
 
 UBOOT_MACHINE = "x1_defconfig"
 SPL_BINARY = "spl/u-boot-spl.bin"


### PR DESCRIPTION
Use weak assignment for KERNEL_DEVICETREE as in the other machine definitions in this layer. This makes it possible to set a custom or modified device tree in conf/local.conf.