### PR TITLE
Add support for OrangePi RV2 on mainline Linux kernel (6.18-rc1)

### DIFF
--- a/conf/machine/orangepi-rv2-mainline.conf
+++ b/conf/machine/orangepi-rv2-mainline.conf
@@ -1,0 +1,53 @@
+#@TYPE: Machine
+#@NAME: orangepi-rv2-mainline
+#@SOC: Spacemit K1
+#@DESCRIPTION: Machine configuration for OrangePi RV2 with mainline Linux
+
+require conf/machine/include/riscv/tune-riscv.inc
+
+# Make sure the orangepi-rv2 machine overrides are still functional
+# by adding orangepi-rv2 to the overrides.
+
+# This part is a bit hacky as MACHINE (orangepi-rv2-mainline) is already
+# part of the overrides. But this way, we are sure that orangepi-rv2-mainline
+# overrides take precendence over orangepi-rv2 ones, as overrides
+# are read from right to left.
+
+# Better solution: insert orangepi-rv2 right before orangepi-rv2-mainline
+# in MACHINEOVERRIDES (do it with a Python function)
+
+MACHINEOVERRIDES:append = ":orangepi-rv2:orangepi-rv2-mainline"
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi-mainline"
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-orangepi"
+
+DTB = "k1-orangepi-rv2.dtb"
+KERNEL_DEVICETREE ?= "spacemit/${DTB}"
+
+UBOOT_MACHINE = "x1_defconfig"
+SPL_BINARY = "spl/u-boot-spl.bin"
+UBOOT_ENV = "boot"
+UBOOT_ENV_SUFFIX = "scr"
+
+RISCV_SBI_PLAT = "generic"
+
+KERNEL_CLASSES = "kernel"
+KERNEL_IMAGETYPE = "Image"
+
+EXTRA_IMAGEDEPENDS += "u-boot-orangepi"
+
+IMAGE_BOOT_FILES += " \
+	${UBOOT_ENV}.${UBOOT_ENV_SUFFIX} \
+	${DTB} \
+	${KERNEL_IMAGETYPE} \
+	initramfs.img"
+
+INITRAMFS_FSTYPES = "cpio.gz"
+IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
+
+WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+WKS_FILE ?= "orangepi-rv2.wks"
+
+SERIAL_CONSOLES = "115200;ttyS0"
+MACHINE_FEATURES = "screen keyboard ext2 ext4 serial"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware-orangepi"

--- a/recipes-bsp/u-boot/u-boot-orangepi/orangepi-rv2-mainline/boot.cmd
+++ b/recipes-bsp/u-boot/u-boot-orangepi/orangepi-rv2-mainline/boot.cmd
@@ -1,0 +1,9 @@
+fdt_file=k1-orangepi-rv2.dtb
+
+setenv bootargs "console=ttyS0,115200 earlycon=sbi rw clk_ignore_unused rdinit=/bin/sh"
+
+load mmc 0:3 ${kernel_addr_r} Image
+load mmc 0:3 ${ramdisk_addr_r} initramfs.img
+load mmc 0:3 ${fdt_addr_r} ${fdt_file}
+
+booti ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr_r}

--- a/recipes-kernel/linux/linux-orangepi-mainline.bb
+++ b/recipes-kernel/linux/linux-orangepi-mainline.bb
@@ -1,0 +1,34 @@
+SUMMARY = "Orange Pi Mainline Linux Kernel"
+
+inherit kernel
+require recipes-kernel/linux/linux-yocto.inc
+
+DEPENDS:append:orangepi-rv2-mainline = " u-boot-tools-native"
+
+LIC_FILES_CHKSUM:orangepi-rv2-mainline = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+BRANCH:orangepi-rv2-mainline = "master"
+SRCREV:orangepi-rv2-mainline = "9b332cece987ee1790b2ed4c989e28162fa47860"
+
+LINUX_VERSION:orangepi-rv2-mainline = "6.18-rc1"
+LINUX_VERSION_EXTENSION:append:orangepi-rv2-mainline = "-orangepi-rv2"
+
+# Disable do_kernel_configcheck, failing on 6.18+ (not fixed yet on Oct. 15, 2025)
+KMETA_AUDIT = ""
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;protocol=https;branch=${BRANCH}"
+
+INITRAMFS_IMAGE:orangepi-rv2-mainline = "core-image-minimal-initramfs"
+
+KCONFIG_MODE = "alldefconfig"
+KBUILD_DEFCONFIG:orangepi-rv2-mainline = "defconfig"
+
+do_deploy:append:orangepi-rv2-mainline() {
+	cd ${DEPLOY_DIR_IMAGE}
+	mkimage -A riscv -O linux -T ramdisk -n "Initial Ram Disk" \
+		-d ${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz initramfs.img
+}
+
+COMPATIBLE_MACHINE = "(orangepi-rv2-mainline)"


### PR DESCRIPTION
This PR proposes to add support for the OrangePi RV2 on mainline Linux kernel (6.18-rc1), by introducing a new "orangepi-rv2-mainline" machine and a new "linux-orangepi-mainline" kernel recipe.

This should make it easier for people to contribute to mainline kernel and u-boot support for this board.

Is this the best approach to introduce mainline support for a board supported by vendor kernel and bootloader code? I could also work in a dedicated branch that we could eventually merge when it's ready. However, I guess the code would stay in my own repository, and would therefore reach a much more narrow audience.

I'm looking forward to your suggestions and comments.

@alperak @kraj 