### PR TITLE
SECURITY.md: add file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+How to Report a Potential Vulnerability?
+========================================
+
+Confirmed or potential security vulnerabilities in the meta-riscv layer should
+be submitted directly via the
+[Issues](https://github.com/riscv/meta-riscv/issues) page.
+
+If you are dealing with a not-yet released or urgent issue, please send a
+message to one of the maintainers listed in the [README](README.md). Include as
+many details as possible:
+  - the layer or software module affected
+  - the recipe and its version
+  - any example code, if available
+
+Branches maintained with security fixes
+---------------------------------------
+
+See https://wiki.yoctoproject.org/wiki/Releases for the list of current
+releases.  We only accept patches for the LTS releases and the master branch.


### PR DESCRIPTION
This is one of the basic requirements for achieving Yocto Project Compatible Status, so add a simple one telling users to file issues or contact the maintainers.

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>