### PR TITLE
kas: add support for orangepi-rv2

### DIFF
--- a/kas/orangepi-rv2-mainline.yml
+++ b/kas/orangepi-rv2-mainline.yml
@@ -1,0 +1,6 @@
+header:
+  version: 20
+  includes:
+    - base-riscv.yml
+
+machine: orangepi-rv2-mainline

--- a/kas/orangepi-rv2.yml
+++ b/kas/orangepi-rv2.yml
@@ -1,0 +1,6 @@
+header:
+  version: 20
+  includes:
+    - base-riscv.yml
+
+machine: orangepi-rv2


### PR DESCRIPTION
For both "orangepi-rv2-mainline" and "orangepi-rv2" machines