### PR TITLE
beaglev-ahead.conf: sparse images and add flashing script helper

### DIFF
--- a/.github/workflows/check-layer.yml
+++ b/.github/workflows/check-layer.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           git clone --depth 1 --branch master https://github.com/openembedded/openembedded-core.git
           git clone --depth 1 --branch master https://github.com/openembedded/bitbake.git openembedded-core/bitbake
+          git clone --depth 1 --branch master https://github.com/openembedded/meta-openembedded.git
           chown -R builduser:builduser $GITHUB_WORKSPACE
 
       - name: Run yocto-check-layer-wrapper
@@ -51,5 +52,6 @@ jobs:
           su builduser -s /bin/bash -c "
             export LANG=en_US.UTF-8 &&
             source $GITHUB_WORKSPACE/openembedded-core/oe-init-build-env $GITHUB_WORKSPACE/build &&
+            bitbake-layers add-layer $GITHUB_WORKSPACE/meta-openembedded/meta-oe &&
             bitbake-layers add-layer $GITHUB_WORKSPACE/meta-riscv &&
-            yocto-check-layer-wrapper $GITHUB_WORKSPACE/meta-riscv"
+            yocto-check-layer-wrapper $GITHUB_WORKSPACE/meta-riscv --dependency $GITHUB_WORKSPACE/meta-openembedded/meta-oe"

--- a/.github/workflows/check-layer.yml
+++ b/.github/workflows/check-layer.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           git clone --depth 1 --branch master https://github.com/openembedded/openembedded-core.git
           git clone --depth 1 --branch master https://github.com/openembedded/bitbake.git openembedded-core/bitbake
+          git clone --depth 1 --branch master https://github.com/openembedded/meta-openembedded.git
           chown -R builduser:builduser $GITHUB_WORKSPACE
 
       - name: Run yocto-check-layer-wrapper
@@ -51,5 +52,6 @@ jobs:
           su builduser -s /bin/bash -c "
             export LANG=en_US.UTF-8 &&
             source $GITHUB_WORKSPACE/openembedded-core/oe-init-build-env $GITHUB_WORKSPACE/build &&
+            bitbake-layers add-layer $GITHUB_WORKSPACE/meta-openembedded/meta-oe &&
             bitbake-layers add-layer $GITHUB_WORKSPACE/meta-riscv &&
-            yocto-check-layer-wrapper $GITHUB_WORKSPACE/meta-riscv"
+            yocto-check-layer-wrapper $GITHUB_WORKSPACE/meta-riscv --dependency $GITHUB_WORKSPACE/meta-openembedded/meta-oe --no-auto-dependency"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This layer depends on:
 * URI: https://github.com/openembedded/openembedded-core
   * branch: master
   * revision: HEAD
+* URI: https://github.com/openembedded/meta-openembedded.git
+  * branch: master
+  * revision: HEAD
 * URI: https://github.com/openembedded/bitbake
   * branch: master
   * revision: HEAD

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,6 +23,8 @@ BBFILES_DYNAMIC += " \
     \
 "
 
+LAYERDEPENDS_riscv-layer = "core openembedded-layer"
+
 LAYERSERIES_COMPAT_riscv-layer = "wrynose"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/conf/machine/beaglev-ahead.conf
+++ b/conf/machine/beaglev-ahead.conf
@@ -33,6 +33,9 @@ UBOOT_DTB_BINARY = "th1520-beaglev-ahead.dtb"
 IMAGE_BOOT_FILES:remove = "boot.scr.uimg"
 IMAGE_BOOT_FILES:append = "fw_payload.bin th1520-beaglev-ahead.dtb extlinux_sd.conf;extlinux/extlinux.conf"
 WKS_FILE ?= "beaglev-ahead.wks"
+# The rootfs must be sparsed
+IMAGE_CLASSES += "image_types_sparse"
+IMAGE_FSTYPES += "ext4.sparse"
 #============================================
 
 #============================================
@@ -41,4 +44,9 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-beaglev-dev"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-beaglev-ahead"
 PREFERRED_PROVIDER_opensbi ?= "opensbi-revyos"
 EXTRA_IMAGEDEPENDS += "u-boot-beaglev-ahead firmware-th1520"
+#============================================
+
+#============================================
+# Some helpers
+MACHINE_EXTRA_RRECOMMENDS += "flashing-script"
 #============================================

--- a/docs/BeagleV-Ahead.md
+++ b/docs/BeagleV-Ahead.md
@@ -61,10 +61,15 @@ fastboot reboot
 sleep 10
 fastboot oem format
 fastboot flash uboot ./u-boot-with-spl.bin
-fastboot flash boot ./boot.ext4
-fastboot flash root ./core-image-minimal-beaglev-ahead.rootfs.ext4
+fastboot flash boot ./boot.ext4.simg
+fastboot flash root ./core-image-minimal-beaglev-ahead.rootfs.ext4.simg
 fastboot reboot
 ```
+
+> **_NOTE:_**  You can also use the helper script:
+> ```shell
+> ./flash.sh
+> ```
 
 Check Functionality
 ===================

--- a/recipes-kernel/linux/linux-beaglev-dev.bb
+++ b/recipes-kernel/linux/linux-beaglev-dev.bb
@@ -26,7 +26,7 @@ SRC_URI = " \
 
 COMPATIBLE_MACHINE = "(beaglev-ahead)"
 
-DEPENDS += "e2fsprogs-native firmware-th1520"
+DEPENDS += "android-tools-native e2fsprogs-ext4sparse-native e2fsprogs-native firmware-th1520"
 
 # package a separate partition boot.ext4 that can be flashed via fastboot to partition boot
 do_deploy:append() {
@@ -55,6 +55,8 @@ do_deploy:append() {
 
     dd if=/dev/zero of=${DEPLOYDIR}/boot.ext4 bs=1 count=0 seek=190M
     mkfs.ext4 -F ${DEPLOYDIR}/boot.ext4 -d ${DEPLOYDIR}/.boot
+    # Sparse the file so it can be flashed with flastboot without error
+    ext2simg_android ${DEPLOYDIR}/boot.ext4 ${DEPLOYDIR}/boot.ext4.simg
 }
 
 addtask deploy after do_compile before do_build

--- a/recipes-support/flashing-scripts/files/beaglev-ahead/flash.sh
+++ b/recipes-support/flashing-scripts/files/beaglev-ahead/flash.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+IMAGE_TO_FLASH=${1:-core-image-minimal-beaglev-ahead.rootfs.ext4.simg}
+
+fastboot_wait_for_device() {
+    echo -n "Waiting for device "
+    while ! fastboot devices | grep -q .; do
+        sleep 1
+        echo -n "."
+    done
+    echo ""
+}
+
+
+echo "Please plug the BeagleV-Ahead board to your computer while maintaining the USB button"
+echo "See: https://docs.beagleboard.org/boards/beaglev/ahead/02-quick-start.html#put-beaglev-ahead-in-usb-flash-mode"
+fastboot_wait_for_device
+
+echo "Flashing $IMAGE_TO_FLASH"
+fastboot flash ram ./u-boot-with-spl.bin
+fastboot reboot
+fastboot_wait_for_device
+
+fastboot oem format
+fastboot flash uboot ./u-boot-with-spl.bin
+fastboot flash boot ./boot.ext4.simg
+fastboot flash root ./${IMAGE_TO_FLASH}
+echo "Flashing done"
+fastboot reboot

--- a/recipes-support/flashing-scripts/files/flash.sh
+++ b/recipes-support/flashing-scripts/files/flash.sh
@@ -1,0 +1,1 @@
+echo "Generic flash.sh script that you can customize for your machine."

--- a/recipes-support/flashing-scripts/flashing-script_1.0.bb
+++ b/recipes-support/flashing-scripts/flashing-script_1.0.bb
@@ -1,0 +1,24 @@
+DESCRIPTION = "Simple flashing script deployed to deploy/ dir"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit deploy
+
+EXCLUDE_FROM_WORLD = "1"
+INHIBIT_DEFAULT_DEPS = "1"
+# Only one empty meta-package
+PACKAGES = "${PN}"
+
+SRC_URI = "file://flash.sh"
+
+S = "${UNPACKDIR}"
+
+do_deploy() {
+    install -D -m 0744 "${S}/flash.sh" "${DEPLOYDIR}/"
+}
+addtask deploy after do_patch
+
+# Remove unnecessary tasks.
+deltask do_configure
+deltask do_compile
+deltask do_install


### PR DESCRIPTION
- conf/machine/beaglev-ahead.conf: inherit image_types_sparse from meta-openembedded layer so the rootfs can be converted to a sparse image otherwise fastboot will likely fail to flash it.

- recipes-kernel/linux/linux-beaglev-dev.bb: sparse the boot.ext4 image to remove the 'fastboot flash boot boot.ext4' command generate a warning message "Invalid sparse file format at header magic"

- recipes-support/flashing-scripts/flashing-script_1.0.bb: introducing a new "deploy only recipe" that deploy a flash.sh utility script to deploydir/. This may help end user to flash the device.

Signed-off-by: Leo Sartre <leo@missingno.tech>
