### PR TITLE
fixes to pass yocto check layer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ Instead of dding wic.gz image ```bmaptool``` (available in most Linux distributi
 $ sudo bmaptool copy <image>-<machine>.wic.gz /dev/sdX
 ```
 
+## Contributing
+
+Submit patches via GitHub pull requests, Use GitHub issues to report problems or to send comments.
+
 ## Maintainer(s)
 
-* Khem Raj `<raj dot khem at gmail.com>`
+* Khem Raj `<raj.khem@gmail.com>`

--- a/recipes-kernel/linux/linux-starfive/0001-riscv-fix-building-external-modules.patch
+++ b/recipes-kernel/linux/linux-starfive/0001-riscv-fix-building-external-modules.patch
@@ -3,6 +3,8 @@ From: Andreas Schwab <schwab@suse.de>
 Date: Tue, 2 Nov 2021 16:51:43 +0100
 Subject: [PATCH] riscv: fix building external modules
 
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5a19c7e06236a9c55dfc001bb4d1a8f1950d23e7]
+
 When building external modules, vdso_prepare should not be run.  If the
 kernel sources are read-only, it will fail.
 


### PR DESCRIPTION
This combination of changes should allow yocto-check-layer to pass when tested against meta-riscv. I've tested it locally like so:

```
yocto-check-layer --debug --dependency ../meta -- ../../meta-riscv 2>&1 | tee meta-riscv-check-layer.log
```

It would be good if others could also test this, however. I do know that there are unrelated issues in Python 3.14-based hosts with bitbake, so it may be best to do this test on a distro other than Fedora 43 (or in a container).

Note that if you are going to test it, you do NOT want meta-riscv specified in bblayers.conf (the `--dependency` flag tells yocto-check-layer what dependencies the layer under test expects).

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>