### PR TITLE
boot-bundle: set COMPATIBLE_MACHINE to 'k1'

### DIFF
--- a/recipes-bsp/u-boot/boot-bundle.bb
+++ b/recipes-bsp/u-boot/boot-bundle.bb
@@ -3,6 +3,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 PROVIDES = "boot-bundle"
 
+COMPATIBLE_MACHINE = "(k1)"
+
 # Useful to use mainline U-Boot when it doesn't support MMC yet
 # This way, everything can be loaded from the vendors U-Boot SPL
 # when it loads mainline U-Boot.


### PR DESCRIPTION
Fixes: #578

boot-bundle is currently only compatible with the k1 family of chips. Make sure to set COMPATIBLE_MACHINE to reflect this so that various sanity checks (e.g. yocto-check-layer) continue to pass.

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>

