### PR TITLE
u-boot-spl-k1: fix openssl/evp.h include not found

### DIFF
--- a/recipes-bsp/u-boot/u-boot-spl-k1.bb
+++ b/recipes-bsp/u-boot/u-boot-spl-k1.bb
@@ -15,7 +15,7 @@ UBOOT_SPL_MACHINE ??= "k1_defconfig"
 EXTRA_OEMAKE = "\
     CROSS_COMPILE=${TARGET_PREFIX} \
     ARCH=riscv \
-    HOSTCC='${BUILD_CC}' \
+    HOSTCC='${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}' \
     HOSTCXX='${BUILD_CXX}' \
 "
 


### PR DESCRIPTION
This fixes the following build error:
  HOSTCC  tools/image-host.o
  WRAP    tools/boot/image-host.c
tools/Makefile:271: warning: pattern recipe did not update peer target 'tools/lib/image-host.c'.
tools/Makefile:271: warning: pattern recipe did not update peer target 'tools/env/image-host.c'.
tools/Makefile:271: warning: pattern recipe did not update peer target 'tools/common/image-host.c'.
In file included from tools/imagetool.h:24,
                 from tools/mkimage.h:22,
                 from tools/image-host.c:11:
include/image.h:1254:12: fatal error: openssl/evp.h: No such file or directory
 1254 | #  include <openssl/evp.h>
      |            ^~~~~~~~~~~~~~~
compilation terminated.

Fixes: 7b28bb1902fa ("u-boot-spl-k1: new recipe")