### PR TITLE
opensbi: use default version on k1 SoC

### DIFF
--- a/recipes-bsp/opensbi/opensbi_%.bbappend
+++ b/recipes-bsp/opensbi/opensbi_%.bbappend
@@ -7,8 +7,6 @@ SRCREV:ae350-ax45mp = "22f38ee6c658a660083aa45c4ec6c72f66a17260"
 SRCREV:jh7100 = "1725bd71080960290fdde4499a58c25c09d5c8ee"
 SRCREV:star64 = "c6a092cd80112529cb2e92e180767ff5341b22a3"
 SRCREV:orangepi-rv2 = "89bff4a7e4cadfb5f130edb1ec44c39bff20a427"
-# Master branch on Dec 12, 2025, includes SpacemiT K1 fixes
-SRCREV:k1 = "51fe6a8bc958166ff79805cf69bafe5e297776f4"
 
 SRC_URI:star64 = "git://github.com/starfive-tech/opensbi;branch=JH7110_VisionFive2_devel;protocol=https"
 SRC_URI:append:star64 = "\


### PR DESCRIPTION
The default version is now sufficient
and also allows to fix this issue that has recently appeared:

ERROR: opensbi-1.8.1-r0 do_unpack: Bitbake Fetcher Error: FetchError("The revision the git tag 'v1.8.1' resolved to didn't match the SRCREV in use (74434f255873d74e56cc50aa762d1caf24c099f8 vs 51fe6a8bc958166ff79805cf69bafe5e297776f4)", 'git://github.com/riscv/opensbi.git;branch=master;protocol=https;tag=v1.8.1')