### PR TITLE
u-boot-spl-k1: make it compatible with k1 SoC only

### DIFF
--- a/recipes-bsp/u-boot/u-boot-spl-k1.bb
+++ b/recipes-bsp/u-boot/u-boot-spl-k1.bb
@@ -37,3 +37,5 @@ do_deploy() {
 }
 
 addtask deploy before do_build after do_compile
+
+COMPATIBLE_MACHINE = "(k1)"


### PR DESCRIPTION
By setting COMPATIBLE_MACHINE = "(k1)"
This way, other machines and SoCs don't pick it up by mistake

Addressing this issue:
https://github.com/riscv/meta-riscv/issues/582