### PR TITLE
kas: add qemuriscv64.yml file

### DIFF
--- a/kas/qemuriscv64.yml
+++ b/kas/qemuriscv64.yml
@@ -1,0 +1,6 @@
+header:
+  version: 20
+  includes:
+    - base-riscv.yml
+
+machine: qemuriscv64


### PR DESCRIPTION
Useful to test the "qemuriscv64" machine (defined in openembedded-core) in the context of this layer.