### PR TITLE
manifest: switch remote from YoeDistro to RISC-V

### DIFF
--- a/tools/manifests/riscv-yocto.xml
+++ b/tools/manifests/riscv-yocto.xml
@@ -3,14 +3,13 @@
 <manifest>
   <remote name="openembedded" fetch="https://github.com/openembedded/" />
   <remote name="riscv" fetch="https://github.com/riscv/" />
-  <remote name="yoe" fetch="https://github.com/YoeDistro/" />
   <remote name="yocto" fetch="https://git.yoctoproject.org/" />
   <default remote="openembedded" revision="master" />
 
-  <project name="meta-riscv" remote="yoe" path="layers/meta-riscv" revision="yoe/mut" />
   <project name="openembedded-core" remote="openembedded" path="layers/openembedded-core" revision="master" />
   <project name="bitbake" remote="openembedded" path="layers/openembedded-core/bitbake" revision="master" />
   <project name="meta-openembedded" remote="openembedded" path="layers/meta-openembedded" revision="master" />
+  <project name="meta-riscv" remote="riscv" path="layers/meta-riscv" revision="master" />
   <project name="meta-yocto" remote="yocto" path="layers/meta-yocto" revision="master" />
 
 </manifest>


### PR DESCRIPTION
- Remove the `yoe` remote along with the dependency of meta-riscv
- Add the official `riscv` remote and update meta-riscv to track the upstream master branch.

This aligns the manifest with the official RISC-V meta-riscv layer and ensures tracking of the latest upstream development.

fixes #586 