### PR TITLE
machine: eswin-ebc77-mainline and eswin-ebc77: fix uboot-extlinux-config

### DIFF
--- a/conf/machine/eswin-ebc77-mainline.conf
+++ b/conf/machine/eswin-ebc77-mainline.conf
@@ -55,4 +55,5 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove = "kernel-image-image"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS:append = " kernel-modules"
 
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+WKS_FILE_DEPENDS:append = " u-boot"
 WKS_FILE ?= "eswin-ebc77.wks"

--- a/conf/machine/eswin-ebc77.conf
+++ b/conf/machine/eswin-ebc77.conf
@@ -55,4 +55,5 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove = "kernel-image-image"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS:append = " kernel-modules"
 
 WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+WKS_FILE_DEPENDS:append = " u-boot"
 WKS_FILE ?= "eswin-ebc77.wks"


### PR DESCRIPTION
Doing a clean build I noticed that extlinux.conf as part of uboot-extlinux-config is not really built leading to the following error:

| DEBUG: ['install', '-m', '0644', '-D', 'riscv-yocto/build/tmp/deploy/images/eswin-ebc77-mainline/extlinux.conf', 'riscv-yocto/build/tmp/work/eswin_ebc77_mainline-poky-linux/core-image-full-cmdline/1.0/tmp-wic/boot.1/extlinux/extlinux.conf']
| ERROR: _exec_cmd: install -m 0644 -D riscv-yocto/build/tmp/deploy/images/eswin-ebc77-mainline/extlinux.conf riscv-yocto/build/tmp/work/eswin_ebc77_mainline-poky-linux/core-image-full-cmdline/1.0/tmp-wic/boot.1/extlinux/extlinux.conf returned '1' instead of 0
| output: install: cannot stat 'riscv-yocto/build/tmp/deploy/images/eswin-ebc77-mainline/extlinux.conf': No such file or directory

Fixes: 3f5a6caca74d ("machine: add eswin-ebc77")
Fixes: ebf5913469d4 ("machine: add eswin-ebc77-mainline")

Signed-off-by: Marcel Ziswiler <marcel@ziswiler.com>