### PR TITLE
K1: use linux 7.0 rc5, update patches

### DIFF
--- a/recipes-kernel/linux/linux-mainline-k1.bb
+++ b/recipes-kernel/linux/linux-mainline-k1.bb
@@ -16,7 +16,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;prot
            file://0005-riscv-dts-spacemit-k1-orangepi-rv2-add-PMIC-and-powe.patch \
            file://0006-riscv-dts-spacemit-k1-orangepi-rv2-add-SD-card-suppo.patch \
            file://0007-riscv-dts-spacemit-k1-bananapi-f3-add-SD-card-suppor.patch \
-           file://0001-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch \
+           file://0008-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch \
           "
 SRCREV = "c369299895a591d96745d6492d4888259b004a9e"
 KBUILD_DEFCONFIG ?= "defconfig"

--- a/recipes-kernel/linux/linux-mainline-k1.bb
+++ b/recipes-kernel/linux/linux-mainline-k1.bb
@@ -18,8 +18,8 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;prot
            file://0007-riscv-dts-spacemit-k1-bananapi-f3-add-SD-card-suppor.patch \
            file://0001-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch \
           "
-SRCREV = "f338e77383789c0cae23ca3d48adcc5e9e137e3c"
+SRCREV = "c369299895a591d96745d6492d4888259b004a9e"
 KBUILD_DEFCONFIG ?= "defconfig"
-LINUX_VERSION = "7.0-rc4"
+LINUX_VERSION = "7.0-rc5"
 
 COMPATIBLE_MACHINE = "(k1)"

--- a/recipes-kernel/linux/linux-mainline-k1/0001-mmc-sdhci-of-k1-enable-essential-clock-infrastructur.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0001-mmc-sdhci-of-k1-enable-essential-clock-infrastructur.patch
@@ -1,11 +1,11 @@
-From c349b093e3e0605a4ef2a77826edf37ef39212ea Mon Sep 17 00:00:00 2001
+From fbde838bddd5eda5bb8a9c9dc72b370533d6be67 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 16 Mar 2026 15:03:29 +0100
-Subject: [PATCH 1/7] mmc: sdhci-of-k1: enable essential clock infrastructure
+Date: Mon, 23 Mar 2026 11:19:04 +0100
+Subject: [PATCH 1/8] mmc: sdhci-of-k1: enable essential clock infrastructure
  for SD operation
 
 Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#]
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Ensure SD card pins receive clock signals by enabling pad clock
 generation and overriding automatic clock gating. Required for all SD
@@ -21,6 +21,8 @@ SDHC_FORCE_CLK_ON) are conditionally applied only for SD-only
 controllers to handle removable card scenarios.
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
+Acked-by: Adrian Hunter <adrian.hunter@intel.com>
+Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
  drivers/mmc/host/sdhci-of-k1.c | 13 +++++++++++++

--- a/recipes-kernel/linux/linux-mainline-k1/0002-mmc-sdhci-of-k1-add-regulator-and-pinctrl-voltage-sw.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0002-mmc-sdhci-of-k1-add-regulator-and-pinctrl-voltage-sw.patch
@@ -1,11 +1,11 @@
-From dbbfd715b098f9ab8891599ec3b08bc82ac380b4 Mon Sep 17 00:00:00 2001
+From 18b49be39e2b70357f7b24770383635dfa160655 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 16 Mar 2026 15:03:30 +0100
-Subject: [PATCH 2/7] mmc: sdhci-of-k1: add regulator and pinctrl voltage
+Date: Mon, 23 Mar 2026 11:19:05 +0100
+Subject: [PATCH 2/8] mmc: sdhci-of-k1: add regulator and pinctrl voltage
  switching support
 
 Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#]
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Add voltage switching infrastructure for UHS-I modes by integrating both
 regulator framework (for supply voltage control) and pinctrl state
@@ -20,13 +20,14 @@ This provides complete voltage switching support while maintaining
 backward compatibility when pinctrl states are not defined.
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
+Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
- drivers/mmc/host/sdhci-of-k1.c | 58 ++++++++++++++++++++++++++++++++++
- 1 file changed, 58 insertions(+)
+ drivers/mmc/host/sdhci-of-k1.c | 72 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 72 insertions(+)
 
 diff --git a/drivers/mmc/host/sdhci-of-k1.c b/drivers/mmc/host/sdhci-of-k1.c
-index 585c7eca6ebf..b2cd35f275ac 100644
+index 585c7eca6ebf..1231b814aa64 100644
 --- a/drivers/mmc/host/sdhci-of-k1.c
 +++ b/drivers/mmc/host/sdhci-of-k1.c
 @@ -15,6 +15,7 @@
@@ -47,46 +48,59 @@ index 585c7eca6ebf..b2cd35f275ac 100644
  };
  
  /* All helper functions will update clr/set while preserve rest bits */
-@@ -218,6 +222,33 @@ static void spacemit_sdhci_pre_hs400_to_hs200(struct mmc_host *mmc)
+@@ -218,6 +222,46 @@ static void spacemit_sdhci_pre_hs400_to_hs200(struct mmc_host *mmc)
  			       SPACEMIT_SDHC_PHY_CTRL_REG);
  }
  
-+static void spacemit_sdhci_voltage_switch(struct sdhci_host *host)
++static int spacemit_sdhci_start_signal_voltage_switch(struct mmc_host *mmc,
++						      struct mmc_ios *ios)
 +{
++	struct sdhci_host *host = mmc_priv(mmc);
 +	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
 +	struct spacemit_sdhci_host *sdhst = sdhci_pltfm_priv(pltfm_host);
-+	struct mmc_ios *ios = &host->mmc->ios;
++	struct pinctrl_state *state;
 +	int ret;
 +
++	ret = sdhci_start_signal_voltage_switch(mmc, ios);
++	if (ret)
++		return ret;
++
 +	if (!sdhst->pinctrl)
-+		return;
++		return 0;
 +
-+	if (ios->signal_voltage != MMC_SIGNAL_VOLTAGE_180) {
-+		dev_warn(mmc_dev(host->mmc), "unsupported voltage %d\n",
-+			 ios->signal_voltage);
-+		return;
++	/* Select appropriate pinctrl state based on signal voltage */
++	switch (ios->signal_voltage) {
++	case MMC_SIGNAL_VOLTAGE_330:
++		state = sdhst->pinctrl_default;
++		break;
++	case MMC_SIGNAL_VOLTAGE_180:
++		state = sdhst->pinctrl_uhs;
++		break;
++	default:
++		dev_warn(mmc_dev(mmc), "unsupported voltage %d\n", ios->signal_voltage);
++		return 0;
 +	}
 +
-+	if (sdhst->pinctrl_uhs) {
-+		ret = pinctrl_select_state(sdhst->pinctrl, sdhst->pinctrl_uhs);
-+		if (ret) {
-+			dev_warn(mmc_dev(host->mmc),
-+				 "failed to select UHS pinctrl state: %d\n", ret);
-+			return;
-+		}
-+		dev_dbg(mmc_dev(host->mmc), "switched to UHS pinctrl state\n");
++	ret = pinctrl_select_state(sdhst->pinctrl, state);
++	if (ret) {
++		dev_warn(mmc_dev(mmc), "failed to select pinctrl state: %d\n", ret);
++		return 0;
 +	}
++	dev_dbg(mmc_dev(mmc), "switched to %s pinctrl state\n",
++		ios->signal_voltage == MMC_SIGNAL_VOLTAGE_180 ? "UHS" : "default");
++
++	return 0;
 +}
 +
  static inline int spacemit_sdhci_get_clocks(struct device *dev,
  					    struct sdhci_pltfm_host *pltfm_host)
  {
-@@ -236,12 +267,37 @@ static inline int spacemit_sdhci_get_clocks(struct device *dev,
+@@ -236,6 +280,30 @@ static inline int spacemit_sdhci_get_clocks(struct device *dev,
  	return 0;
  }
  
 +static inline void spacemit_sdhci_get_pins(struct device *dev,
-+					    struct sdhci_pltfm_host *pltfm_host)
++					   struct sdhci_pltfm_host *pltfm_host)
 +{
 +	struct spacemit_sdhci_host *sdhst = sdhci_pltfm_priv(pltfm_host);
 +
@@ -112,18 +126,13 @@ index 585c7eca6ebf..b2cd35f275ac 100644
  static const struct sdhci_ops spacemit_sdhci_ops = {
  	.get_max_clock		= spacemit_sdhci_clk_get_max_clock,
  	.reset			= spacemit_sdhci_reset,
- 	.set_bus_width		= sdhci_set_bus_width,
- 	.set_clock		= spacemit_sdhci_set_clock,
- 	.set_uhs_signaling	= spacemit_sdhci_set_uhs_signaling,
-+	.voltage_switch         = spacemit_sdhci_voltage_switch,
- };
- 
- static const struct sdhci_pltfm_data spacemit_sdhci_k1_pdata = {
-@@ -293,6 +349,8 @@ static int spacemit_sdhci_probe(struct platform_device *pdev)
+@@ -293,6 +361,10 @@ static int spacemit_sdhci_probe(struct platform_device *pdev)
  
  	host->mmc->caps |= MMC_CAP_NEED_RSP_BUSY;
  
 +	spacemit_sdhci_get_pins(dev, pltfm_host);
++
++	host->mmc_host_ops.start_signal_voltage_switch = spacemit_sdhci_start_signal_voltage_switch;
 +
  	ret = spacemit_sdhci_get_clocks(dev, pltfm_host);
  	if (ret)

--- a/recipes-kernel/linux/linux-mainline-k1/0003-mmc-sdhci-of-k1-add-comprehensive-SDR-tuning-support.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0003-mmc-sdhci-of-k1-add-comprehensive-SDR-tuning-support.patch
@@ -1,10 +1,13 @@
-From e3f03b488f6a833efc2c8d4f2616744eee88ebbf Mon Sep 17 00:00:00 2001
+From 4cbeb924f2dd2900fefd02a63dd3ab597acedfb7 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 16 Mar 2026 15:03:31 +0100
-Subject: [PATCH 3/7] mmc: sdhci-of-k1: add comprehensive SDR tuning support
+Date: Mon, 23 Mar 2026 11:19:06 +0100
+Subject: [PATCH 3/8] mmc: sdhci-of-k1: add comprehensive SDR tuning support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#]
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Implement software tuning algorithm to enable UHS-I SDR modes for SD
 card operation and HS200 mode for eMMC. This adds both TX and RX delay
@@ -21,13 +24,15 @@ Algorithm features:
   for improved reliability
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
+Acked-by: Adrian Hunter <adrian.hunter@intel.com>
+Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
  drivers/mmc/host/sdhci-of-k1.c | 172 +++++++++++++++++++++++++++++++++
  1 file changed, 172 insertions(+)
 
 diff --git a/drivers/mmc/host/sdhci-of-k1.c b/drivers/mmc/host/sdhci-of-k1.c
-index b2cd35f275ac..3fe4675e6760 100644
+index 1231b814aa64..43701857ec01 100644
 --- a/drivers/mmc/host/sdhci-of-k1.c
 +++ b/drivers/mmc/host/sdhci-of-k1.c
 @@ -68,6 +68,28 @@
@@ -222,10 +227,10 @@ index b2cd35f275ac..3fe4675e6760 100644
  static int spacemit_sdhci_pre_select_hs400(struct mmc_host *mmc)
  {
  	struct sdhci_host *host = mmc_priv(mmc);
-@@ -298,6 +469,7 @@ static const struct sdhci_ops spacemit_sdhci_ops = {
+@@ -310,6 +481,7 @@ static const struct sdhci_ops spacemit_sdhci_ops = {
+ 	.set_bus_width		= sdhci_set_bus_width,
  	.set_clock		= spacemit_sdhci_set_clock,
  	.set_uhs_signaling	= spacemit_sdhci_set_uhs_signaling,
- 	.voltage_switch         = spacemit_sdhci_voltage_switch,
 +	.platform_execute_tuning = spacemit_sdhci_execute_tuning,
  };
  

--- a/recipes-kernel/linux/linux-mainline-k1/0004-riscv-dts-spacemit-k1-add-SD-card-controller-and-pin.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0004-riscv-dts-spacemit-k1-add-SD-card-controller-and-pin.patch
@@ -1,11 +1,11 @@
-From ebe876efd72af823464b1289fa7eb695b181d9dd Mon Sep 17 00:00:00 2001
+From 7a0c6c57e5f5fb8bb0eb445832657804e4a4851d Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 16 Mar 2026 15:03:32 +0100
-Subject: [PATCH 4/7] riscv: dts: spacemit: k1: add SD card controller and
+Date: Mon, 23 Mar 2026 11:19:07 +0100
+Subject: [PATCH 4/8] riscv: dts: spacemit: k1: add SD card controller and
  pinctrl support
 
 Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#]
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Add SD card controller infrastructure for SpacemiT K1 SoC with complete
 pinctrl support for both standard and UHS modes.
@@ -19,6 +19,7 @@ This provides complete SD card infrastructure that K1-based boards can
 enable.
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
+Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
  arch/riscv/boot/dts/spacemit/k1-pinctrl.dtsi | 40 ++++++++++++++++++++

--- a/recipes-kernel/linux/linux-mainline-k1/0005-riscv-dts-spacemit-k1-orangepi-rv2-add-PMIC-and-powe.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0005-riscv-dts-spacemit-k1-orangepi-rv2-add-PMIC-and-powe.patch
@@ -1,11 +1,11 @@
-From 5f86ca57d490894a839bc5c9aa775949bc76a111 Mon Sep 17 00:00:00 2001
+From 248cdbe419b19d7584681a979526617ad9aada0d Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 16 Mar 2026 15:03:33 +0100
-Subject: [PATCH 5/7] riscv: dts: spacemit: k1-orangepi-rv2: add PMIC and power
+Date: Mon, 23 Mar 2026 11:19:08 +0100
+Subject: [PATCH 5/8] riscv: dts: spacemit: k1-orangepi-rv2: add PMIC and power
  infrastructure
 
 Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#]
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Add Spacemit P1 PMIC configuration and board power infrastructure for
 voltage regulation support.
@@ -16,24 +16,25 @@ voltage regulation support.
 - Set up regulator constraints for SD card operation
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
+Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
  .../boot/dts/spacemit/k1-orangepi-rv2.dts     | 48 +++++++++++++++++++
  1 file changed, 48 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts b/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
-index 7b7331cb3c72..f1533c99881d 100644
+index 7b7331cb3c72..9c417a483f6b 100644
 --- a/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
 +++ b/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
 @@ -19,6 +19,25 @@ aliases {
  		ethernet1 = &eth1;
  	};
  
-+	reg_dc_in: dc-in-12v {
++	reg_dc_in: dc-in-5v {
 +		compatible = "regulator-fixed";
-+		regulator-name = "dc_in_12v";
-+		regulator-min-microvolt = <12000000>;
-+		regulator-max-microvolt = <12000000>;
++		regulator-name = "dc_in_5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
 +		regulator-boot-on;
 +		regulator-always-on;
 +	};

--- a/recipes-kernel/linux/linux-mainline-k1/0006-riscv-dts-spacemit-k1-orangepi-rv2-add-SD-card-suppo.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0006-riscv-dts-spacemit-k1-orangepi-rv2-add-SD-card-suppo.patch
@@ -1,11 +1,11 @@
-From 52549a968345cf07cc62b07fc35d78b49d9d5e27 Mon Sep 17 00:00:00 2001
+From 6ca5785b06a137196f30833408bd64a1afb81383 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 16 Mar 2026 15:03:34 +0100
-Subject: [PATCH 6/7] riscv: dts: spacemit: k1-orangepi-rv2: add SD card
+Date: Mon, 23 Mar 2026 11:19:09 +0100
+Subject: [PATCH 6/8] riscv: dts: spacemit: k1-orangepi-rv2: add SD card
  support with UHS modes
 
 Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#]
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Add complete SD card controller support with UHS high-speed modes.
 
@@ -21,13 +21,14 @@ for improved performance.
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
+Tested-by: Michael Opdenacker <michael.opdenacker@rootcommit.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
  .../boot/dts/spacemit/k1-orangepi-rv2.dts     | 19 +++++++++++++++++++
  1 file changed, 19 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts b/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
-index f1533c99881d..aff23846085d 100644
+index 9c417a483f6b..5f823611c969 100644
 --- a/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
 +++ b/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
 @@ -140,3 +140,22 @@ aldo1: aldo1 {

--- a/recipes-kernel/linux/linux-mainline-k1/0007-riscv-dts-spacemit-k1-bananapi-f3-add-SD-card-suppor.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0007-riscv-dts-spacemit-k1-bananapi-f3-add-SD-card-suppor.patch
@@ -1,11 +1,11 @@
-From 645e9233b07f51438a0b2245eb7080259a24b593 Mon Sep 17 00:00:00 2001
+From b3134ed9b7e04a28f8b79268b35cb5125b55e377 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 16 Mar 2026 15:03:35 +0100
-Subject: [PATCH 7/7] riscv: dts: spacemit: k1-bananapi-f3: add SD card support
+Date: Mon, 23 Mar 2026 11:19:10 +0100
+Subject: [PATCH 7/8] riscv: dts: spacemit: k1-bananapi-f3: add SD card support
  with UHS modes
 
 Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#]
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Add complete SD card controller support with UHS high-speed modes.
 
@@ -20,13 +20,14 @@ This enables full SD card functionality including high-speed UHS modes
 for improved performance.
 
 Suggested-by: Anand Moon <linux.amoon@gmail.com>
+Tested-by: Anand Moon <linux.amoon@gmail.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
- .../boot/dts/spacemit/k1-bananapi-f3.dts      | 23 +++++++++++++++++--
- 1 file changed, 21 insertions(+), 2 deletions(-)
+ .../boot/dts/spacemit/k1-bananapi-f3.dts      | 24 +++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)
 
 diff --git a/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts b/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
-index 5971605754b3..50f30aeac711 100644
+index 5971605754b3..ba348e6a8bb9 100644
 --- a/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
 +++ b/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
 @@ -214,7 +214,7 @@ buck3_1v8: buck3 {
@@ -47,7 +48,7 @@ index 5971605754b3..50f30aeac711 100644
  				regulator-min-microvolt = <500000>;
  				regulator-max-microvolt = <3400000>;
  				regulator-boot-on;
-@@ -359,3 +359,22 @@ hub_3_0: hub@2 {
+@@ -359,3 +359,23 @@ hub_3_0: hub@2 {
  		reset-gpios = <&gpio K1_GPIO(124) GPIO_ACTIVE_LOW>;
  	};
  };
@@ -59,6 +60,7 @@ index 5971605754b3..50f30aeac711 100644
 +	bus-width = <4>;
 +	cd-gpios = <&gpio K1_GPIO(80) GPIO_ACTIVE_HIGH>;
 +	cd-inverted;
++	broken-cd;
 +	no-mmc;
 +	no-sdio;
 +	disable-wp;

--- a/recipes-kernel/linux/linux-mainline-k1/0008-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0008-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch
@@ -1,10 +1,11 @@
-From 76acc75047693960a203ea1dbacbcaaf88535427 Mon Sep 17 00:00:00 2001
+From 7b11dd107525221cfd6ebd9fb22ea8f8aaf35404 Mon Sep 17 00:00:00 2001
 From: Trevor Gamblin <tgamblin@baylibre.com>
-Date: Thu, 12 Mar 2026 09:52:57 -0400
-Subject: [PATCH] riscv: dts: spacemit: k1-musepi-pro: add SD card support with
- UHS modes
+Date: Mon, 23 Mar 2026 11:19:11 +0100
+Subject: [PATCH 8/8] riscv: dts: spacemit: k1-musepi-pro: add SD card support
+ with UHS modes
 
-Upstream-Status: Pending
+Upstream-Status: Submitted
+[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
 
 Update the Muse Pi Pro devicetree with SD card support to match what
 was done for the OrangePi RV2 in [1]. More precisely:
@@ -18,8 +19,8 @@ was done for the OrangePi RV2 in [1]. More precisely:
 
 [1] https://lore.kernel.org/linux-riscv/20260316-orangepi-sd-card-uhs-v3-0-aefd3b7832df@gmail.com/T/#
 
-Co-developed-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
+Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
 ---
  .../riscv/boot/dts/spacemit/k1-musepi-pro.dts | 66 +++++++++++++++++++
  1 file changed, 66 insertions(+)


### PR DESCRIPTION
Update the `linux-mainline-k1` recipe to use version `7.0-rc5`, and also update the carried patch series to v4, which includes an `Upstream-Status: Submitted` tag instead of `Pending` for the `muse-pi-pro.dts` changes, as those are in the latest revision.

Tested on my Muse Pi Pro:
```
Poky (Yocto Project Reference Distro) 5.3.99+snapshot-8061433fcd11eba91a29004dfafd175d449fb2fd muse-pi-pro ttyS0

Type 'root' to login with superuser privileges (no password will be asked).

muse-pi-pro login: root

WARNING: Poky is a reference Yocto Project distribution that should be used for
testing and development purposes only. It is recommended that you create your
own distribution for production use.

root@muse-pi-pro:~# uname -a
Linux muse-pi-pro 7.0.0-rc5-00008-g8aae86923061 #1 SMP PREEMPT Sun Mar 22 21:42:17 UTC 2026 riscv64 GNU/Linux
root@muse-pi-pro:~#
```