### PR TITLE
Fixes #618, a path dependency issue in the environment setup script

### DIFF
--- a/tools/envsetup.sh
+++ b/tools/envsetup.sh
@@ -32,7 +32,7 @@ elif [ "${0##*/}" = "dash" ]; then
 fi
 # bootstrap OE
 echo "Init OE"
-export BASH_SOURCE="openembedded-core/oe-init-build-env"
+export BASH_SOURCE="${LAYERS_ROOT}/openembedded-core/oe-init-build-env"
 . ${LAYERS_ROOT}/openembedded-core/oe-init-build-env ${BUILD_DIR}
 
 # Symlink the cache


### PR DESCRIPTION
I initially do not have a Yocto project environment.

When setting up the environment according to the steps in the [Quick Start](https://github.com/riscv/meta-riscv/blob/master/docs/QUICK_START.md) , I got following error at step [Setup Build Environment](https://github.com/riscv/meta-riscv/blob/master/docs/QUICK_START.md#setup-build-environment).

```bash
$ . layers/meta-riscv/tools/envsetup.sh
Init OE
/home/ubuntu/tmp/layers/openembedded-core/oe-init-build-env:.:45: no such file or directory: /home/ubuntu/tmp/openembedded-core/scripts/oe-buildenv-internal
Adding layers
layers/meta-riscv/tools/envsetup.sh:44: command not found: bitbake-layers
layers/meta-riscv/tools/envsetup.sh:45: command not found: bitbake-layers
layers/meta-riscv/tools/envsetup.sh:46: command not found: bitbake-layers
layers/meta-riscv/tools/envsetup.sh:47: command not found: bitbake-layers
layers/meta-riscv/tools/envsetup.sh:48: command not found: bitbake-layers
layers/meta-riscv/tools/envsetup.sh:49: command not found: bitbake-layers
Creating auto.conf
layers/meta-riscv/tools/envsetup.sh:57: no such file or directory: conf/auto.conf
To build an image run
---------------------------------------------------
bitbake core-image-full-cmdline
---------------------------------------------------

Buildable machine info
---------------------------------------------------
* qemuriscv64: The 64-bit RISC-V machine
* qemuriscv32: The 32-bit RISC-V machine
* freedom-u540: The SiFive HiFive Unleashed board
---------------------------------------------------
```

From the log, it can be seen that the path used to run the `oe-buildenv-internal` script is missing the `/layers/` directory. This patch adds `${LAYERS_ROOT}` to `BASH_SOURCE`.


Signed-off-by: gsh1209 <gsh1209@outlook.com>