### PR TITLE
k1-vendor.inc: introduce vendor include

### DIFF
--- a/conf/machine/include/k1-vendor.inc
+++ b/conf/machine/include/k1-vendor.inc
@@ -10,3 +10,31 @@ require conf/machine/include/riscv/tune-riscv.inc
 require conf/machine/include/soc-family.inc
 
 SOC_FAMILY = "k1"
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi"
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-orangepi"
+
+UBOOT_MACHINE = "x1_defconfig"
+SPL_BINARY = "spl/u-boot-spl.bin"
+UBOOT_ENV = "boot"
+UBOOT_ENV_SUFFIX = "scr"
+
+RISCV_SBI_PLAT = "generic"
+
+KERNEL_CLASSES = "kernel"
+KERNEL_IMAGETYPE = "Image"
+
+EXTRA_IMAGEDEPENDS += "u-boot-orangepi"
+
+IMAGE_BOOT_FILES += " \
+	${UBOOT_ENV}.${UBOOT_ENV_SUFFIX} \
+	${KERNEL_IMAGETYPE} \
+	initramfs.img"
+
+INITRAMFS_FSTYPES = "cpio.gz"
+IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
+
+WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
+
+SERIAL_CONSOLES = "115200;ttyS0"
+MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"

--- a/conf/machine/include/k1-vendor.inc
+++ b/conf/machine/include/k1-vendor.inc
@@ -1,0 +1,12 @@
+#@TYPE: SOC
+#@NAME: SpacemiT K1
+#@SOC: SpacemiT K1
+#@DESCRIPTION: SOC configuration for the SpacemiT K1 SoC - vendor repo version
+
+# This include is ONLY to be used for vendor-tree based builds for K1 platforms
+# like the OrangePi RV2 and R2S. For mainline support, rely on k1.inc.
+
+require conf/machine/include/riscv/tune-riscv.inc
+require conf/machine/include/soc-family.inc
+
+SOC_FAMILY = "k1"

--- a/conf/machine/orangepi-r2s.conf
+++ b/conf/machine/orangepi-r2s.conf
@@ -3,7 +3,7 @@
 #@SOC: Ky X1
 #@DESCRIPTION: Machine configuration for OrangePi R2S
 
-require include/k1.inc
+require include/k1-vendor.inc
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-orangepi"

--- a/conf/machine/orangepi-r2s.conf
+++ b/conf/machine/orangepi-r2s.conf
@@ -5,35 +5,11 @@
 
 require include/k1-vendor.inc
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi"
-PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-orangepi"
-
 KERNEL_DEVICETREE ?= "ky/x1_orangepi-r2s.dtb"
 
-UBOOT_MACHINE = "x1_defconfig"
-SPL_BINARY = "spl/u-boot-spl.bin"
-UBOOT_ENV = "boot"
-UBOOT_ENV_SUFFIX = "scr"
-
-RISCV_SBI_PLAT = "generic"
-
-KERNEL_CLASSES = "kernel"
-KERNEL_IMAGETYPE = "Image"
-
-EXTRA_IMAGEDEPENDS += "u-boot-orangepi"
-
 IMAGE_BOOT_FILES += " \
-	${UBOOT_ENV}.${UBOOT_ENV_SUFFIX} \
-	x1_orangepi-r2s.dtb \
-	${KERNEL_IMAGETYPE} \
-	initramfs.img"
+	x1_orangepi-r2s.dtb"
 
-INITRAMFS_FSTYPES = "cpio.gz"
-IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
-
-WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 WKS_FILE ?= "orangepi-r2s-usb.wks"
 
-SERIAL_CONSOLES = "115200;ttyS0"
-MACHINE_FEATURES = "keyboard ext2 ext3 serial"
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules"

--- a/conf/machine/orangepi-rv2.conf
+++ b/conf/machine/orangepi-rv2.conf
@@ -5,35 +5,11 @@
 
 require include/k1-vendor.inc
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi"
-PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-orangepi"
-
 KERNEL_DEVICETREE ?= "ky/x1_orangepi-rv2.dtb"
 
-UBOOT_MACHINE = "x1_defconfig"
-SPL_BINARY = "spl/u-boot-spl.bin"
-UBOOT_ENV = "boot"
-UBOOT_ENV_SUFFIX = "scr"
-
-RISCV_SBI_PLAT = "generic"
-
-KERNEL_CLASSES = "kernel"
-KERNEL_IMAGETYPE = "Image"
-
-EXTRA_IMAGEDEPENDS += "u-boot-orangepi"
-
 IMAGE_BOOT_FILES += " \
-	${UBOOT_ENV}.${UBOOT_ENV_SUFFIX} \
-	x1_orangepi-rv2.dtb \
-	${KERNEL_IMAGETYPE} \
-	initramfs.img"
+	x1_orangepi-rv2.dtb"
 
-INITRAMFS_FSTYPES = "cpio.gz"
-IMAGE_FSTYPES += "wic.gz wic.bmap ext4"
-
-WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
 WKS_FILE ?= "orangepi-rv2.wks"
 
-SERIAL_CONSOLES = "115200;ttyS0"
-MACHINE_FEATURES = "screen keyboard ext2 ext3 serial"
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware-orangepi"

--- a/conf/machine/orangepi-rv2.conf
+++ b/conf/machine/orangepi-rv2.conf
@@ -3,7 +3,7 @@
 #@SOC: Ky X1
 #@DESCRIPTION: Machine configuration for OrangePi RV2
 
-require include/k1.inc
+require include/k1-vendor.inc
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-orangepi"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-orangepi"


### PR DESCRIPTION
Switching to a common k1.inc for all of the mainline-based board recipes accidentally broke the vendor MACHINEs for the OrangePi RV2 and R2S. We are still interested in supporting these for now, so create a variant of the .inc file which matches the previous iteration but with a clear indication of its focus on the vendor-based configurations.

Thanks to @michaelopdenacker for pointing this out.

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>

