### PR TITLE
meta-riscv: initial deprecation changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,11 @@ If this PR fixes an issue, make sure your description includes "fixes #xxxx".
 
 If this PR connects to an issue, make sure your description includes "connected to #xxxx".
 
+If you are adding a new BSP, please review the DEPRECATED.md file to confirm
+that it has not previously been removed. If you are modifying an existing BSP
+which is slated for removal in an upcoming release, consider whether the changes
+are necessary before that occurs. If needed, open a new issue or discussion.
+
 Please provide the following information:
 -->
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,9 @@
+# Deprecated BSPs
+
+The following is a list of `MACHINE` values which will no longer be supported as
+of the listed releases.
+
+## Yocto 6.1
+
+- beaglev
+- visionfive

--- a/classes/warn-deprecated-machines.bbclass
+++ b/classes/warn-deprecated-machines.bbclass
@@ -1,0 +1,21 @@
+# Print a warning when a build is started with a MACHINE which is slated to be
+# removed as of a future Yocto Project release.
+
+python warn_deprecated_machines() {
+    deprecated_machines = {
+        "beaglev-starlight-jh7100": "Yocto 6.1",
+        "visionfive": "Yocto 6.1",
+    }
+
+    machine = d.getVar("MACHINE")
+
+    if machine in deprecated_machines:
+        removal_release = deprecated_machines[machine]
+        bb.warn(
+            f"MACHINE='{machine}' is deprecated and will no longer be supported "
+            f"after {removal_release}. Please consider an alternative BSP."
+        )
+}
+
+addhandler warn_deprecated_machines
+warn_deprecated_machines[eventmask] = "bb.event.BuildStarted"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -157,3 +157,6 @@ COMPATIBLE_HOST:pn-samba:riscv32 = "null"
 COMPATIBLE_HOST:pn-smbnetfs:riscv32 = "null"
 COMPATIBLE_HOST:pn-gnome-control-center:riscv32 = "null"
 COMPATIBLE_HOST:pn-thunar-shares-plugin:riscv32 = "null"
+
+# Use our deprecation warning function
+INHERIT += "warn-deprecated-machines"


### PR DESCRIPTION
1. Add classes/warn-deprecated-machines.bbclass with a Python function, then INHERIT it in conf/layer.conf, which allows for warnings like this:

```
Build Configuration:
BB_VERSION           = "2.16.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "riscv64-poky-linux"
MACHINE              = "visionfive"
SDKMACHINE           = "x86_64"
DISTRO               = "poky"
DISTRO_VERSION       = "5.3.99+snapshot-5a60dca0fb81695e26149e45aad9a9eee7c955ec"
TUNE_FEATURES        = "rv 64 i m a f d c zicsr zifencei"
meta                 = "master:5a60dca0fb81695e26149e45aad9a9eee7c955ec"
meta-riscv           = "tgamblin/deprecation-warnings:5e26903faa31d42c707ee8ae54df7f1997bbc4d0"
meta-yocto-bsp
meta-poky            = "master:266eed66396f9c12ed6fdbd24626f555815af0b1"

WARNING: MACHINE='visionfive' is deprecated and will no longer be supported after Yocto 6.1. Please consider an alternative BSP.
```

2. Add a `DEPRECATED.md` file at the top level, listing deprecated `MACHINE` values and their corresponding removal release.

3. Modify the pull request template with a message about checking for deprecated BSPs and related decision making.