### PR TITLE
linux-mainline-k1: move to v7.0, K1 series v8

### DIFF
--- a/recipes-kernel/linux/linux-mainline-k1.bb
+++ b/recipes-kernel/linux/linux-mainline-k1.bb
@@ -9,17 +9,18 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;prot
            file://nfs.cfg \
            file://misc.cfg \
            file://k1-i2c.cfg \
-           file://0001-mmc-sdhci-of-k1-enable-essential-clock-infrastructur.patch \
-           file://0002-mmc-sdhci-of-k1-add-regulator-and-pinctrl-voltage-sw.patch \
-           file://0003-mmc-sdhci-of-k1-add-comprehensive-SDR-tuning-support.patch \
-           file://0004-riscv-dts-spacemit-k1-add-SD-card-controller-and-pin.patch \
+           file://0001-dt-bindings-mmc-spacemit-sdhci-add-pinctrl-support-f.patch \
+           file://0002-mmc-sdhci-of-k1-enable-essential-clock-infrastructur.patch \
+           file://0003-mmc-sdhci-of-k1-add-regulator-and-pinctrl-voltage-sw.patch \
+           file://0004-mmc-sdhci-of-k1-add-comprehensive-SDR-tuning-support.patch \
            file://0005-riscv-dts-spacemit-k1-orangepi-rv2-add-PMIC-and-powe.patch \
            file://0006-riscv-dts-spacemit-k1-orangepi-rv2-add-SD-card-suppo.patch \
            file://0007-riscv-dts-spacemit-k1-bananapi-f3-add-SD-card-suppor.patch \
            file://0008-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch \
+           file://0009-riscv-dts-spacemit-k1-add-SD-card-controller-and-pin.patch \
           "
-SRCREV = "c369299895a591d96745d6492d4888259b004a9e"
+SRCREV = "028ef9c96e96197026887c0f092424679298aae8"
 KBUILD_DEFCONFIG ?= "defconfig"
-LINUX_VERSION = "7.0-rc5"
+LINUX_VERSION = "7.0"
 
 COMPATIBLE_MACHINE = "(k1)"

--- a/recipes-kernel/linux/linux-mainline-k1/0001-dt-bindings-mmc-spacemit-sdhci-add-pinctrl-support-f.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0001-dt-bindings-mmc-spacemit-sdhci-add-pinctrl-support-f.patch
@@ -1,0 +1,59 @@
+From 55891e71ff68990e7ff8c7e098349d9335e257e7 Mon Sep 17 00:00:00 2001
+From: Iker Pedrosa <ikerpedrosam@gmail.com>
+Date: Mon, 13 Apr 2026 10:02:10 +0200
+Subject: [PATCH 1/9] dt-bindings: mmc: spacemit,sdhci: add pinctrl support for
+ voltage switching
+
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
+
+Document pinctrl properties to support voltage-dependent pin
+configuration switching for UHS-I SD card modes.
+
+Add optional pinctrl-names property with two states:
+- "default": For 3.3V operation with standard drive strength
+- "state_uhs": For 1.8V operation with optimized drive strength
+
+These pinctrl states allow the SDHCI driver to coordinate voltage
+switching with pin configuration changes, ensuring proper signal
+integrity during UHS-I mode transitions.
+
+Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
+---
+ .../devicetree/bindings/mmc/spacemit,sdhci.yaml   | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/mmc/spacemit,sdhci.yaml b/Documentation/devicetree/bindings/mmc/spacemit,sdhci.yaml
+index 13d9382058fb..55965a28dcc3 100644
+--- a/Documentation/devicetree/bindings/mmc/spacemit,sdhci.yaml
++++ b/Documentation/devicetree/bindings/mmc/spacemit,sdhci.yaml
+@@ -32,6 +32,18 @@ properties:
+       - const: core
+       - const: io
+ 
++  pinctrl-names:
++    minItems: 1
++    items:
++      - const: default
++      - const: uhs
++
++  pinctrl-0:
++    description: Default pinctrl state for 3.3V operation
++
++  pinctrl-1:
++    description: Optional pinctrl state for 1.8V UHS operation with "uhs" name
++
+ required:
+   - compatible
+   - reg
+@@ -50,4 +62,7 @@ examples:
+       interrupt-parent = <&plic>;
+       clocks = <&clk_apmu 10>, <&clk_apmu 13>;
+       clock-names = "core", "io";
++      pinctrl-names = "default", "uhs";
++      pinctrl-0 = <&sdhci_default_cfg>;
++      pinctrl-1 = <&sdhci_uhs_cfg>;
+     };
+-- 
+2.53.0
+

--- a/recipes-kernel/linux/linux-mainline-k1/0002-mmc-sdhci-of-k1-enable-essential-clock-infrastructur.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0002-mmc-sdhci-of-k1-enable-essential-clock-infrastructur.patch
@@ -1,11 +1,10 @@
-From fbde838bddd5eda5bb8a9c9dc72b370533d6be67 Mon Sep 17 00:00:00 2001
+From 460124f8f59fae18819a1aca8cf120c660f05198 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 23 Mar 2026 11:19:04 +0100
-Subject: [PATCH 1/8] mmc: sdhci-of-k1: enable essential clock infrastructure
+Date: Mon, 13 Apr 2026 10:02:11 +0200
+Subject: [PATCH 2/9] mmc: sdhci-of-k1: enable essential clock infrastructure
  for SD operation
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Ensure SD card pins receive clock signals by enabling pad clock
 generation and overriding automatic clock gating. Required for all SD
@@ -23,7 +22,10 @@ controllers to handle removable card scenarios.
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Acked-by: Adrian Hunter <adrian.hunter@intel.com>
 Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
+Reviewed-by: Troy Mitchell <troy.mitchell@linux.dev>
+Tested-by: Vincent Legoll <legoll@online.fr>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
 ---
  drivers/mmc/host/sdhci-of-k1.c | 13 +++++++++++++
  1 file changed, 13 insertions(+)

--- a/recipes-kernel/linux/linux-mainline-k1/0003-mmc-sdhci-of-k1-add-regulator-and-pinctrl-voltage-sw.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0003-mmc-sdhci-of-k1-add-regulator-and-pinctrl-voltage-sw.patch
@@ -1,11 +1,10 @@
-From 18b49be39e2b70357f7b24770383635dfa160655 Mon Sep 17 00:00:00 2001
+From 5d26fda70262e1811d69013dd140db766e17a862 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 23 Mar 2026 11:19:05 +0100
-Subject: [PATCH 2/8] mmc: sdhci-of-k1: add regulator and pinctrl voltage
+Date: Mon, 13 Apr 2026 10:02:12 +0200
+Subject: [PATCH 3/9] mmc: sdhci-of-k1: add regulator and pinctrl voltage
  switching support
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Add voltage switching infrastructure for UHS-I modes by integrating both
 regulator framework (for supply voltage control) and pinctrl state
@@ -21,13 +20,17 @@ backward compatibility when pinctrl states are not defined.
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
+Acked-by: Adrian Hunter <adrian.hunter@intel.com>
+Reviewed-by: Troy Mitchell <troy.mitchell@linux.dev>
+Tested-by: Vincent Legoll <legoll@online.fr>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
 ---
  drivers/mmc/host/sdhci-of-k1.c | 72 ++++++++++++++++++++++++++++++++++
  1 file changed, 72 insertions(+)
 
 diff --git a/drivers/mmc/host/sdhci-of-k1.c b/drivers/mmc/host/sdhci-of-k1.c
-index 585c7eca6ebf..1231b814aa64 100644
+index 585c7eca6ebf..1aea0206f0ed 100644
 --- a/drivers/mmc/host/sdhci-of-k1.c
 +++ b/drivers/mmc/host/sdhci-of-k1.c
 @@ -15,6 +15,7 @@
@@ -115,7 +118,7 @@ index 585c7eca6ebf..1231b814aa64 100644
 +	if (IS_ERR(sdhst->pinctrl_default))
 +		sdhst->pinctrl_default = NULL;
 +
-+	sdhst->pinctrl_uhs = pinctrl_lookup_state(sdhst->pinctrl, "state_uhs");
++	sdhst->pinctrl_uhs = pinctrl_lookup_state(sdhst->pinctrl, "uhs");
 +	if (IS_ERR(sdhst->pinctrl_uhs))
 +		sdhst->pinctrl_uhs = NULL;
 +

--- a/recipes-kernel/linux/linux-mainline-k1/0004-mmc-sdhci-of-k1-add-comprehensive-SDR-tuning-support.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0004-mmc-sdhci-of-k1-add-comprehensive-SDR-tuning-support.patch
@@ -1,13 +1,12 @@
-From 4cbeb924f2dd2900fefd02a63dd3ab597acedfb7 Mon Sep 17 00:00:00 2001
+From 1bff222f565519e399f89f5b28db60a1f32cf326 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 23 Mar 2026 11:19:06 +0100
-Subject: [PATCH 3/8] mmc: sdhci-of-k1: add comprehensive SDR tuning support
+Date: Mon, 13 Apr 2026 10:02:13 +0200
+Subject: [PATCH 4/9] mmc: sdhci-of-k1: add comprehensive SDR tuning support
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Implement software tuning algorithm to enable UHS-I SDR modes for SD
 card operation and HS200 mode for eMMC. This adds both TX and RX delay
@@ -26,13 +25,15 @@ Algorithm features:
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Acked-by: Adrian Hunter <adrian.hunter@intel.com>
 Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
+Tested-by: Vincent Legoll <legoll@online.fr>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
 ---
  drivers/mmc/host/sdhci-of-k1.c | 172 +++++++++++++++++++++++++++++++++
  1 file changed, 172 insertions(+)
 
 diff --git a/drivers/mmc/host/sdhci-of-k1.c b/drivers/mmc/host/sdhci-of-k1.c
-index 1231b814aa64..43701857ec01 100644
+index 1aea0206f0ed..a5cb047f24d6 100644
 --- a/drivers/mmc/host/sdhci-of-k1.c
 +++ b/drivers/mmc/host/sdhci-of-k1.c
 @@ -68,6 +68,28 @@

--- a/recipes-kernel/linux/linux-mainline-k1/0005-riscv-dts-spacemit-k1-orangepi-rv2-add-PMIC-and-powe.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0005-riscv-dts-spacemit-k1-orangepi-rv2-add-PMIC-and-powe.patch
@@ -1,23 +1,24 @@
-From 248cdbe419b19d7584681a979526617ad9aada0d Mon Sep 17 00:00:00 2001
+From 2151d23bef3de78f312230f01426454dc878f09f Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 23 Mar 2026 11:19:08 +0100
-Subject: [PATCH 5/8] riscv: dts: spacemit: k1-orangepi-rv2: add PMIC and power
+Date: Mon, 13 Apr 2026 10:02:15 +0200
+Subject: [PATCH 5/9] riscv: dts: spacemit: k1-orangepi-rv2: add PMIC and power
  infrastructure
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Add Spacemit P1 PMIC configuration and board power infrastructure for
 voltage regulation support.
 
-- Add board power regulators (12V input, 4V rail)
+- Add board power regulators (5V input, 4V rail)
 - Enable I2C8 for PMIC communication
 - Configure PMIC with buck4 (vmmc) and aldo1 (vqmmc) regulators
 - Set up regulator constraints for SD card operation
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
+Tested-by: Vincent Legoll <legoll@online.fr>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
 ---
  .../boot/dts/spacemit/k1-orangepi-rv2.dts     | 48 +++++++++++++++++++
  1 file changed, 48 insertions(+)

--- a/recipes-kernel/linux/linux-mainline-k1/0006-riscv-dts-spacemit-k1-orangepi-rv2-add-SD-card-suppo.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0006-riscv-dts-spacemit-k1-orangepi-rv2-add-SD-card-suppo.patch
@@ -1,11 +1,10 @@
-From 6ca5785b06a137196f30833408bd64a1afb81383 Mon Sep 17 00:00:00 2001
+From b96f16ded65c88af28a7276d39ab1459eee19e82 Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 23 Mar 2026 11:19:09 +0100
-Subject: [PATCH 6/8] riscv: dts: spacemit: k1-orangepi-rv2: add SD card
+Date: Mon, 13 Apr 2026 10:02:16 +0200
+Subject: [PATCH 6/9] riscv: dts: spacemit: k1-orangepi-rv2: add SD card
  support with UHS modes
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Add complete SD card controller support with UHS high-speed modes.
 
@@ -22,13 +21,15 @@ for improved performance.
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
 Tested-by: Michael Opdenacker <michael.opdenacker@rootcommit.com>
+Tested-by: Vincent Legoll <legoll@online.fr>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
 ---
  .../boot/dts/spacemit/k1-orangepi-rv2.dts     | 19 +++++++++++++++++++
  1 file changed, 19 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts b/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
-index 9c417a483f6b..5f823611c969 100644
+index 9c417a483f6b..95cfb4681ced 100644
 --- a/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
 +++ b/arch/riscv/boot/dts/spacemit/k1-orangepi-rv2.dts
 @@ -140,3 +140,22 @@ aldo1: aldo1 {
@@ -37,7 +38,7 @@ index 9c417a483f6b..5f823611c969 100644
  };
 +
 +&sdhci0 {
-+	pinctrl-names = "default", "state_uhs";
++	pinctrl-names = "default", "uhs";
 +	pinctrl-0 = <&mmc1_cfg>;
 +	pinctrl-1 = <&mmc1_uhs_cfg>;
 +	bus-width = <4>;

--- a/recipes-kernel/linux/linux-mainline-k1/0007-riscv-dts-spacemit-k1-bananapi-f3-add-SD-card-suppor.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0007-riscv-dts-spacemit-k1-bananapi-f3-add-SD-card-suppor.patch
@@ -1,11 +1,10 @@
-From b3134ed9b7e04a28f8b79268b35cb5125b55e377 Mon Sep 17 00:00:00 2001
+From 680acc9cedb9b4795bc5cc136fc623ea09295f3b Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 23 Mar 2026 11:19:10 +0100
-Subject: [PATCH 7/8] riscv: dts: spacemit: k1-bananapi-f3: add SD card support
+Date: Mon, 13 Apr 2026 10:02:17 +0200
+Subject: [PATCH 7/9] riscv: dts: spacemit: k1-bananapi-f3: add SD card support
  with UHS modes
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Add complete SD card controller support with UHS high-speed modes.
 
@@ -22,12 +21,13 @@ for improved performance.
 Suggested-by: Anand Moon <linux.amoon@gmail.com>
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
 ---
  .../boot/dts/spacemit/k1-bananapi-f3.dts      | 24 +++++++++++++++++--
  1 file changed, 22 insertions(+), 2 deletions(-)
 
 diff --git a/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts b/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
-index 5971605754b3..ba348e6a8bb9 100644
+index 5971605754b3..725792600c5d 100644
 --- a/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
 +++ b/arch/riscv/boot/dts/spacemit/k1-bananapi-f3.dts
 @@ -214,7 +214,7 @@ buck3_1v8: buck3 {
@@ -54,7 +54,7 @@ index 5971605754b3..ba348e6a8bb9 100644
  };
 +
 +&sdhci0 {
-+	pinctrl-names = "default", "state_uhs";
++	pinctrl-names = "default", "uhs";
 +	pinctrl-0 = <&mmc1_cfg>;
 +	pinctrl-1 = <&mmc1_uhs_cfg>;
 +	bus-width = <4>;

--- a/recipes-kernel/linux/linux-mainline-k1/0008-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0008-riscv-dts-spacemit-k1-musepi-pro-add-SD-card-support.patch
@@ -1,11 +1,10 @@
-From 7b11dd107525221cfd6ebd9fb22ea8f8aaf35404 Mon Sep 17 00:00:00 2001
+From d072ed3337599379ba5aa5bcefb5f2c0ae7d0772 Mon Sep 17 00:00:00 2001
 From: Trevor Gamblin <tgamblin@baylibre.com>
-Date: Mon, 23 Mar 2026 11:19:11 +0100
-Subject: [PATCH 8/8] riscv: dts: spacemit: k1-musepi-pro: add SD card support
+Date: Mon, 13 Apr 2026 10:02:18 +0200
+Subject: [PATCH 8/9] riscv: dts: spacemit: k1-musepi-pro: add SD card support
  with UHS modes
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Update the Muse Pi Pro devicetree with SD card support to match what
 was done for the OrangePi RV2 in [1]. More precisely:
@@ -26,7 +25,7 @@ Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
  1 file changed, 66 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/spacemit/k1-musepi-pro.dts b/arch/riscv/boot/dts/spacemit/k1-musepi-pro.dts
-index 29e333b670cf..b63723978a4b 100644
+index 29e333b670cf..774a4640f065 100644
 --- a/arch/riscv/boot/dts/spacemit/k1-musepi-pro.dts
 +++ b/arch/riscv/boot/dts/spacemit/k1-musepi-pro.dts
 @@ -18,6 +18,24 @@ aliases {
@@ -89,7 +88,7 @@ index 29e333b670cf..b63723978a4b 100644
 +};
 +
 +&sdhci0 {
-+	pinctrl-names = "default", "state_uhs";
++	pinctrl-names = "default", "uhs";
 +	pinctrl-0 = <&mmc1_cfg>;
 +	pinctrl-1 = <&mmc1_uhs_cfg>;
 +	bus-width = <4>;

--- a/recipes-kernel/linux/linux-mainline-k1/0009-riscv-dts-spacemit-k1-add-SD-card-controller-and-pin.patch
+++ b/recipes-kernel/linux/linux-mainline-k1/0009-riscv-dts-spacemit-k1-add-SD-card-controller-and-pin.patch
@@ -1,11 +1,10 @@
-From 7a0c6c57e5f5fb8bb0eb445832657804e4a4851d Mon Sep 17 00:00:00 2001
+From 4cc3a940e70064b02283e337a114a88df1eb3f9d Mon Sep 17 00:00:00 2001
 From: Iker Pedrosa <ikerpedrosam@gmail.com>
-Date: Mon, 23 Mar 2026 11:19:07 +0100
-Subject: [PATCH 4/8] riscv: dts: spacemit: k1: add SD card controller and
+Date: Mon, 13 Apr 2026 10:02:14 +0200
+Subject: [PATCH 9/9] riscv: dts: spacemit: k1: add SD card controller and
  pinctrl support
 
-Upstream-Status: Submitted
-[https://lore.kernel.org/linux-riscv/20260323-orangepi-sd-card-uhs-v4-0-567c9775fd0e@gmail.com/]
+Upstream-Status: Submitted [https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d]
 
 Add SD card controller infrastructure for SpacemiT K1 SoC with complete
 pinctrl support for both standard and UHS modes.
@@ -20,14 +19,17 @@ enable.
 
 Tested-by: Anand Moon <linux.amoon@gmail.com>
 Tested-by: Trevor Gamblin <tgamblin@baylibre.com>
+Tested-by: Vincent Legoll <legoll@online.fr>
+Reviewed-by: Troy Mitchell <troy.mitchell@linux.dev>
 Signed-off-by: Iker Pedrosa <ikerpedrosam@gmail.com>
+Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>
 ---
  arch/riscv/boot/dts/spacemit/k1-pinctrl.dtsi | 40 ++++++++++++++++++++
  arch/riscv/boot/dts/spacemit/k1.dtsi         | 13 +++++++
  2 files changed, 53 insertions(+)
 
 diff --git a/arch/riscv/boot/dts/spacemit/k1-pinctrl.dtsi b/arch/riscv/boot/dts/spacemit/k1-pinctrl.dtsi
-index b13dcb10f4d6..8d82011f1af6 100644
+index b13dcb10f4d6..b3c472a0783b 100644
 --- a/arch/riscv/boot/dts/spacemit/k1-pinctrl.dtsi
 +++ b/arch/riscv/boot/dts/spacemit/k1-pinctrl.dtsi
 @@ -570,4 +570,44 @@ pwm14-1-pins {
@@ -43,14 +45,14 @@ index b13dcb10f4d6..8d82011f1af6 100644
 +				 <K1_PADCONF(107, 0)>,   /* mmc1_d0 */
 +				 <K1_PADCONF(108, 0)>;   /* mmc1_cmd */
 +			bias-pull-up = <1>;
-+			drive-strength = <7>;
++			drive-strength = <19>;
 +			power-source = <3300>;
 +		};
 +
 +		mmc1-clk-pins {
 +			pinmux = <K1_PADCONF(109, 0)>;   /* mmc1_clk */
 +			bias-pull-down = <1>;
-+			drive-strength = <7>;
++			drive-strength = <19>;
 +			power-source = <3300>;
 +		};
 +	};
@@ -63,14 +65,14 @@ index b13dcb10f4d6..8d82011f1af6 100644
 +				 <K1_PADCONF(107, 0)>,   /* mmc1_d0 */
 +				 <K1_PADCONF(108, 0)>;   /* mmc1_cmd */
 +			bias-pull-up = <1>;
-+			drive-strength = <13>;
++			drive-strength = <42>;
 +			power-source = <1800>;
 +		};
 +
 +		mmc1-clk-pins {
 +			pinmux = <K1_PADCONF(109, 0)>;   /* mmc1_clk */
 +			bias-pull-down = <1>;
-+			drive-strength = <13>;
++			drive-strength = <42>;
 +			power-source = <1800>;
 +		};
 +	};


### PR DESCRIPTION
Use the latest v8 version of the K1 patch series ([1]) providing SD card support, on top of the Linux v7.0 kernel.

[1]: https://lore.kernel.org/linux-riscv/DHSQ6VG82QYX.1EVAYV9JTBCL7@linux.dev/T/#m7019138a8182f8add500d2b753a7071da894b95d

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>

