### PR TITLE
u-boot: drop SRCREV for K1

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -31,9 +31,6 @@ SRC_URI:k1 = " \
             file://bootcommand.cfg \
             "
 
-# Master branch as of Dec 11, 2025
-SRCREV:k1 = "ff80e95fed188ec3d4001129445e414c9c811beb"
-
 SRC_URI:milkv-duo = " \
             git://github.com/milkv-duo/milkv-duo-u-boot;protocol=https;branch=duo-64mb \
             file://uboot-milkv-duo.env \


### PR DESCRIPTION
The .bbappend for u-boot is pinning the SRCREV for K1 builds to `ff80e95fed188ec3d4001129445e414c9c811beb`, which pointed at master in December 2025. With recent updates in oe-core (commit `5e97f3c1e2cf`), a patch was introduced which doesn't apply cleanly on this commit.

Remove the `SRCREV:k1` line in the .bbappend so we build the v2026.04 release version for K1 boards, too.

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>

