### PR TITLE
add basic bitbake-config templates

### DIFF
--- a/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json
+++ b/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json
@@ -1,0 +1,67 @@
+{
+    "description": "meta-riscv and oe-core - 'nodistro' basic configuration",
+    "sources": {
+        "bitbake": {
+            "git-remote": {
+                "uri": "https://git.openembedded.org/bitbake",
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "openembedded-core": {
+            "git-remote": {
+                "uri": "https://git.openembedded.org/openembedded-core",
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "yocto-docs": {
+            "git-remote": {
+                "uri": "https://git.yoctoproject.org/yocto-docs",
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-riscv": {
+            "git-remote": {
+                "uri": "https://github.com/riscv/meta-riscv.git",
+                "branch": "master",
+                "rev": "master"
+            }
+        }
+    },
+    "bitbake-setup": {
+        "configurations": [
+        {
+            "name": "nodistro",
+            "description": "OpenEmbedded 'nodistro'",
+            "setup-dir-name": "oe-nodistro-master-meta-riscv",
+            "bb-layers": ["openembedded-core/meta", "meta-riscv"],
+            "bb-env-passthrough-additions": ["DL_DIR", "SSTATE_DIR"],
+            "oe-fragments-one-of": {
+                "machine": {
+                    "description": "Target machines",
+                    "options" : [
+                        { "name": "machine/bananapi-f3", "description": "BananaPi BPI-F3" },
+                        { "name": "machine/beaglev-ahead", "description": "BeagleV Ahead" },
+                        { "name": "machine/eswin-ebc77", "description": "ESWIN EBC77 (Vendor Kernel)" },
+                        { "name": "machine/freedom-u540", "description": "Freedom U540" },
+                        { "name": "machine/mangopi-mq-pro", "description": "MangoPi MQ Pro" },
+                        { "name": "machine/milkv-duo", "description": "Milk-V Duo" },
+                        { "name": "machine/milkv-megrez", "description": "Milk-V Megrez" },
+                        { "name": "machine/eswin-ebc77-mainline", "description": "ESWIN EBC77 (Mainline Kernel)" },
+                        { "name": "machine/muse-pi-pro", "description": "SpacemiT Muse Pi Pro" },
+                        { "name": "machine/nezha-allwinner-d1", "description": "Nezha D1-H" },
+                        { "name": "machine/orangepi-r2s", "description": "OrangePi R2S" },
+                        { "name": "machine/orangepi-rv2", "description": "OrangePi RV2 (Vendor Kernel)" },
+                        { "name": "machine/orangepi-rv2-mainline", "description": "OrangePi RV2 (Mainline Kernel)" },
+                        { "name": "machine/star64", "description": "PINE64 Star64" },
+                        { "name": "machine/visionfive2", "description": "x86_64 (64-bit) PCs and servers" }
+                    ]
+                }
+            }
+        }
+        ]
+    },
+    "version": "1.0"
+}

--- a/bitbake-registry/meta-riscv-poky-master.conf.json
+++ b/bitbake-registry/meta-riscv-poky-master.conf.json
@@ -1,0 +1,91 @@
+{
+    "description": "meta-riscv master with Poky reference distro",
+    "sources": {
+        "bitbake": {
+            "git-remote": {
+                "uri": "https://git.openembedded.org/bitbake",
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "openembedded-core": {
+            "git-remote": {
+                "uri": "https://git.openembedded.org/openembedded-core",
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-yocto": {
+            "git-remote": {
+                "uri": "https://git.yoctoproject.org/meta-yocto",
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "yocto-docs": {
+            "git-remote": {
+                "uri": "https://git.yoctoproject.org/yocto-docs",
+                "branch": "master",
+                "rev": "master"
+            }
+        },
+        "meta-riscv": {
+            "git-remote": {
+                "uri": "https://github.com/riscv/meta-riscv.git",
+                "branch": "master",
+                "rev": "master"
+            }
+        }
+    },
+    "bitbake-setup": {
+        "configurations": [
+        {
+            "bb-layers": ["openembedded-core/meta","meta-yocto/meta-yocto-bsp","meta-yocto/meta-poky", "meta-riscv"],
+            "bb-env-passthrough-additions": ["DL_DIR", "SSTATE_DIR"],
+            "setup-dir-name": "$distro-master-meta-riscv",
+            "oe-fragments-one-of": {
+                "machine": {
+                    "description": "Target machines",
+                    "options" : [
+                        { "name": "machine/bananapi-f3", "description": "BananaPi BPI-F3" },
+                        { "name": "machine/beaglev-ahead", "description": "BeagleV Ahead" },
+                        { "name": "machine/eswin-ebc77", "description": "ESWIN EBC77 (Vendor Kernel)" },
+                        { "name": "machine/freedom-u540", "description": "Freedom U540" },
+                        { "name": "machine/mangopi-mq-pro", "description": "MangoPi MQ Pro" },
+                        { "name": "machine/milkv-duo", "description": "Milk-V Duo" },
+                        { "name": "machine/milkv-megrez", "description": "Milk-V Megrez" },
+                        { "name": "machine/eswin-ebc77-mainline", "description": "ESWIN EBC77 (Mainline Kernel)" },
+                        { "name": "machine/muse-pi-pro", "description": "SpacemiT Muse Pi Pro" },
+                        { "name": "machine/nezha-allwinner-d1", "description": "Nezha D1-H" },
+                        { "name": "machine/orangepi-r2s", "description": "OrangePi R2S" },
+                        { "name": "machine/orangepi-rv2", "description": "OrangePi RV2 (Vendor Kernel)" },
+                        { "name": "machine/orangepi-rv2-mainline", "description": "OrangePi RV2 (Mainline Kernel)" },
+                        { "name": "machine/star64", "description": "PINE64 Star64" },
+                        { "name": "machine/visionfive2", "description": "x86_64 (64-bit) PCs and servers" }
+                    ]
+                },
+                "distro": {
+                    "description": "Target distributions",
+                    "options" : [
+                        { "name": "distro/poky", "description": "Yocto Project Reference Distro" },
+                        { "name": "distro/poky-altcfg", "description": "Poky alternative with systemd as init manager" },
+                        { "name": "distro/poky-tiny", "description": "Poky alternative optimized for size" }
+                    ]
+                }
+            },
+            "configurations": [
+            {
+                "name": "poky",
+                "description": "Poky - The Yocto Project testing distribution"
+            },
+            {
+                "name": "poky-with-sstate",
+                "description": "Poky - The Yocto Project testing distribution with internet sstate acceleration. Use with caution as it requires a completely robust local network with sufficient bandwidth.",
+                "oe-fragments": ["core/yocto/sstate-mirror-cdn"]
+            }
+            ]
+        }
+        ]
+    },
+    "version": "1.0"
+}

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -4,14 +4,46 @@
 
 Make sure to [install the `repo` command by Google](https://gerrit.googlesource.com/git-repo#install) first.
 
-## Create workspace
+## bitbake-setup
+
+The following examples assumes that you have the `bitbake` repository checked
+out at `~/workspace/yocto/bitbake`, and that you are using the `nodistro`
+variant. They read the config templates from URLs to minimize how much needs to
+be preemptively checked out on the host system. Alternatively, you could clone
+this repository and use the following to achieve the same result:
+
+```
+../bitbake-setup init /path/to/meta-riscv/bitbake-regsitry/your-preferred.conf.json
+```
+
+### Interactively
+
+1. `~/workspace/yocto/bitbake/bin/bitbake-setup init https://raw.githubusercontent.com/riscv/meta-riscv/refs/heads/master/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json`
+2. Provide your choice of MACHINE
+3. Set the workspace name
+4. Confirm workspace setup
+
+bitbake-setup should clone the minimal repository set and provide you with
+further usage instructions.
+
+### Non-Interactively
+
+Using `MACHINE="orangepi-rv2"` as an example:
+
+```
+bitbake-setup init --non-interactive https://raw.githubusercontent.com/riscv/meta-riscv/refs/heads/master/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json nodistro machine/orangepi-r2s
+```
+
+## repo
+
+### Create workspace
 ```text
 mkdir riscv-yocto && cd riscv-yocto
 repo init -u https://github.com/riscv/meta-riscv -b master -m tools/manifests/riscv-yocto.xml
 repo sync
 repo start work --all
 ```
-## Update existing workspace
+### Update existing workspace
 
 In order to bring all the layers up to date with upstream
 
@@ -21,7 +53,10 @@ repo sync
 repo rebase
 ```
 
-## Setup Build Environment
+## envsetup script
+
+Set up the build environment:
+
 ```text
 . layers/meta-riscv/tools/envsetup.sh
 ```


### PR DESCRIPTION
- Add configuration templates for meta-riscv nodistro and poky (both master branch) so that people can make use of bitbake-setup if desired.
- Update `docs/QUICK_START.md` to add a section for bitbake-setup usage, and tweak the other sections so that they are easier to distinguish.

Two notes:

1. The example URLs for bitbake-setup usage in `QUICK_START.md` reference the path that will exist once these templates are merged to master, so they don't work (yet)
2. I've been using these for a couple of weeks now in my own [boardgarden](https://github.com/threexc/boardgarden/tree/main/.forgejo/bitbake-configs) repository (along with some extra overrides, which I will leave there).