### PR TITLE
linux: remove duplicate KBUILD_DEFCONFIG definitions

### DIFF
--- a/recipes-kernel/linux/linux-mainline-common.inc
+++ b/recipes-kernel/linux/linux-mainline-common.inc
@@ -14,8 +14,6 @@ KCONFIG_MODE = "--alldefconfig"
 
 KBUILD_DEFCONFIG ?= "defconfig"
 KBUILD_DEFCONFIG:qemuriscv32 = "rv32_defconfig"
-KBUILD_DEFCONFIG:qemuriscv64 = "defconfig"
-KBUILD_DEFCONFIG:freedom-u540 = "defconfig"
 
 COMPATIBLE_MACHINE = "(qemuriscv32|qemuriscv64|freedom-u540)"
 

--- a/recipes-kernel/linux/linux-mainline-k1.bb
+++ b/recipes-kernel/linux/linux-mainline-k1.bb
@@ -20,7 +20,6 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git;prot
            file://0009-riscv-dts-spacemit-k1-add-SD-card-controller-and-pin.patch \
           "
 SRCREV = "028ef9c96e96197026887c0f092424679298aae8"
-KBUILD_DEFCONFIG ?= "defconfig"
 LINUX_VERSION = "7.0"
 
 COMPATIBLE_MACHINE = "(k1)"


### PR DESCRIPTION
KBUILD_DEFCONFIG ?= "defconfig" is sufficient in
recipes-kernel/linux/linux-mainline-common.inc,
making identical settings redundant.

Similarly, this setting is not necessary in
linux-mainline-k1.bb which includes
linux-mainline-common.inc.