### PR TITLE
u-boot: add u-boot-spl-spacemit.inc, use in u-boot-spl-k1

### DIFF
--- a/recipes-bsp/u-boot/u-boot-spl-k1.bb
+++ b/recipes-bsp/u-boot/u-boot-spl-k1.bb
@@ -1,41 +1,12 @@
-HOMEPAGE = "https://gitee.com/bianbu-linux/uboot-2022.10"
-DESCRIPTION = "U-Boot SPL for SpacemiT K1 SoCs, derived from U-Boot"
-SECTION = "bootloaders"
-DEPENDS += "flex-native bison-native python3-setuptools-native"
-LICENSE = "GPL-2.0-or-later"
-LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
+require u-boot-spl-spacemit.inc
 
-inherit deploy
-
-SRC_URI = "git://github.com/amarula/uboot-2022.10;protocol=https;branch=k1-bl-v2.2.y"
-SRCREV = "c6f2746cb7993a6fb6c9f51b2bff318921e13f98"
-
-UBOOT_SPL_MACHINE ??= "k1_defconfig"
-
-EXTRA_OEMAKE = "\
-    CROSS_COMPILE=${TARGET_PREFIX} \
-    ARCH=riscv \
-    HOSTCC='${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}' \
-    HOSTCXX='${BUILD_CXX}' \
-"
-
-do_configure() {
-	oe_runmake ${UBOOT_SPL_MACHINE}
-}
-
-do_compile() {
-    LIBGCC_PATH=$(${CC} ${CFLAGS} ${LDFLAGS} -print-libgcc-file-name)
-    oe_runmake PLATFORM_LIBGCC="${LIBGCC_PATH}" spl/u-boot-spl.bin
-}
-
-do_deploy() {
-	install -d ${DEPLOYDIR}
-	install -m 644 ${B}/FSBL.bin ${DEPLOYDIR}/
-	install -m 644 ${B}/spl/u-boot-spl.bin ${DEPLOYDIR}/
-	install -m 644 ${B}/bootinfo_emmc.bin ${DEPLOYDIR}/
-	install -m 644 ${B}/bootinfo_sd.bin ${DEPLOYDIR}/
-}
-
-addtask deploy before do_build after do_compile
+BRANCH ?= "k1-bl-v2.2.y"
+SRC_URI = "git://github.com/amarula/uboot-2022.10;protocol=https;branch=${BRANCH}"
+SRCREV ?= "c6f2746cb7993a6fb6c9f51b2bff318921e13f98"
 
 COMPATIBLE_MACHINE = "(k1)"
+
+do_deploy:append() {
+        install -m 644 ${B}/bootinfo_emmc.bin ${DEPLOYDIR}/
+        install -m 644 ${B}/bootinfo_sd.bin ${DEPLOYDIR}/
+}

--- a/recipes-bsp/u-boot/u-boot-spl-spacemit.inc
+++ b/recipes-bsp/u-boot/u-boot-spl-spacemit.inc
@@ -1,0 +1,34 @@
+HOMEPAGE = "https://gitee.com/bianbu-linux/uboot-2022.10"
+DESCRIPTION = "U-Boot SPL for SpacemiT SoCs, derived from U-Boot"
+SECTION = "bootloaders"
+DEPENDS += "flex-native bison-native python3-setuptools-native"
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
+
+inherit deploy
+
+UBOOT_SPL_MACHINE ??= "k1_defconfig"
+
+EXTRA_OEMAKE = "\
+    CROSS_COMPILE=${TARGET_PREFIX} \
+    ARCH=riscv \
+    HOSTCC='${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}' \
+    HOSTCXX='${BUILD_CXX}' \
+"
+
+do_configure() {
+	oe_runmake ${UBOOT_SPL_MACHINE}
+}
+
+do_compile() {
+    LIBGCC_PATH=$(${CC} ${CFLAGS} ${LDFLAGS} -print-libgcc-file-name)
+    oe_runmake PLATFORM_LIBGCC="${LIBGCC_PATH}" spl/u-boot-spl.bin
+}
+
+do_deploy() {
+	install -d ${DEPLOYDIR}
+	install -m 644 ${B}/FSBL.bin ${DEPLOYDIR}/
+	install -m 644 ${B}/spl/u-boot-spl.bin ${DEPLOYDIR}/
+}
+
+addtask deploy before do_build after do_compile


### PR DESCRIPTION
Rework the u-boot-spl-k1 recipe to store the generic functions and repo metadata in a new 'u-boot-spl-spacemit.inc' file, then use the require directive to include that logic in the much-simplified u-boot-spl-k1 recipe. This allows the common elements to be re-used for new BSPs, such as those for the SpacemiT's K3 platforms, which follow the same basic SPL usage pattern.

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>

---

This is a preparatory change for #636 - the early implementation I'm working off of there tries to build the SPL parts in the same recipe as the main U-Boot output, which is at odds with how we currently do things for the K1, and which also requires a non-ideal workaround patch.

If this should be done differently, let me know. I had considered changing `u-boot-spl-k1.bb` to `u-boot-spl.bb` and doing machine-specific variables and functions, but I thought this was clearer and easier to maintain as we go - especially when we add similar BSPs for other K3 board variants (and the future K5 and K7 platforms mentioned [on Reddit](https://www.reddit.com/r/spacemit_riscv/s/Oz2Jx1Sf5U)), especially if they have slight differences in which files they need to deploy.

I've tested this for regressions on my local infra with my BananaPi F3, which uses Labgrid with an SD Mux to let me image and boot the board remotely. I've started uploading these test results to a public mirror - you can see the Labgrid pytest report for the run [here](https://testresults.ecocode.ca/yocto/meta-riscv/bananapi-f3/20260522/1171/report.html?sort=result)
