### PR TITLE
clarify QUICK_START.md structure for new users

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2,17 +2,30 @@
 
 **Note: You only need this if you do not have an existing Yocto Project build environment.**
 
-Make sure to [install the `repo` command by Google](https://gerrit.googlesource.com/git-repo#install) first.
+There are three approaches to get started:
 
-## bitbake-setup
+- **Path A: `bitbake-setup`** — Initialize a build environment using a JSON configuration file.
+Requires a pre-installed `bitbake` checkout.
+- **Path B: `repo`** — Initialize a build environment using Google's `repo` tool with a manifest file.
+- **Path C: `kas`** — Build directly using the [kas](https://github.com/siemens/kas) tool.
+No prior `bitbake` or `repo` setup required.
 
-The following examples assumes that you have the `bitbake` repository checked
+Paths A and B both produce a standard `bitbake` build environment. Once initialized,
+the build and deployment steps are identical ([Build Images](#build-images),
+[Running in QEMU](#running-in-qemu), [Running on hardware](#running-on-hardware)).
+Path C handles initialization and build in one command.
+
+---
+
+## Path A: bitbake-setup
+
+The following examples assume that you have the `bitbake` repository checked
 out at `~/workspace/yocto/bitbake`, and that you are using the `nodistro`
 variant. They read the config templates from URLs to minimize how much needs to
 be preemptively checked out on the host system. Alternatively, you could clone
 this repository and use the following to achieve the same result:
 
-```
+```bash
 ../bitbake-setup init /path/to/meta-riscv/bitbake-regsitry/your-preferred.conf.json
 ```
 
@@ -30,80 +43,85 @@ further usage instructions.
 
 Using `MACHINE="orangepi-rv2"` as an example:
 
-```
+```bash
 bitbake-setup init --non-interactive https://raw.githubusercontent.com/riscv/meta-riscv/refs/heads/master/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json nodistro machine/orangepi-r2s
 ```
 
-## repo
+---
+
+## Path B: repo
+
+Make sure to [install the `repo` command by Google](https://gerrit.googlesource.com/git-repo#install) first.
 
 ### Create workspace
-```text
+
+```bash
 mkdir riscv-yocto && cd riscv-yocto
 repo init -u https://github.com/riscv/meta-riscv -b master -m tools/manifests/riscv-yocto.xml
 repo sync
 repo start work --all
 ```
-### Update existing workspace
 
-In order to bring all the layers up to date with upstream
+### Set up the build environment with `envsetup.sh`
 
-```text
-cd riscv-yocto
-repo sync
-repo rebase
-```
-
-## envsetup script
-
-Set up the build environment:
-
-```text
+```bash
 . layers/meta-riscv/tools/envsetup.sh
 ```
 
 Optionally override the build directory:
 
-```text
+```bash
 BUILD_DIR=<build-riscv> . ./layers/meta-riscv/tools/envsetup.sh
 ```
 
-## Kas Support
+### Update existing workspace
 
-Kas build is supported, you can run the following commands:
+In order to bring all the layers up to date with upstream
 
-```text
+```bash
+cd riscv-yocto
+repo sync
+repo rebase
+```
+
+---
+
+## Path C: kas
+
+```bash
 git clone https://github.com/riscv/meta-riscv.git -b master
 cd meta-riscv
 ```
 
-* For basic `qemuriscv64` build run:
+- For basic `qemuriscv64` build run:
 
-```text
+```bash
 kas build kas/base-riscv.yml
 ```
 
 **base-riscv.yml** will build `core-image-minimal`, you can then boot it with:
 
-```text
+```bash
 runqemu core-image-minimal nographic
 ```
 
 **NOTE** `nographic` is needed for this image, because it has no graphical support for graphical Qemu run.
 
-* For `nezha` build:
+- For `nezha` build:
 
-```text
+```bash
 kas build kas/nezha.yml
 ```
 
-* For `beaglev` build:
+- For `beaglev` build:
 
-```text
+```bash
 kas build kas/beaglev.yml
 ```
 
-* For more machines check `kas` folder.
+- For more machines check `kas` folder.
 
+---
 
 ## Custom Project
 
@@ -127,27 +145,34 @@ target: custom-image # Or nezha default image: riscv-nezha-image
 
 For more details on `nezha`, `beaglev` and other boards steps check `doc` folder.
 
+---
+
 ## Build Images
 
+After completing [Path A](#path-a-bitbake-setup) or [Path B](#path-b-repo), use `bitbake` to build images for your target machine.
+
 A console-only image for the 64-bit QEMU machine
-```text
+
+```bash
 MACHINE=qemuriscv64 bitbake core-image-full-cmdline
 MACHINE=beaglev-starlight-jh7100 bitbake core-image-full-cmdline
 ```
 
 To build an image to run on the HiFive Unleashed using Wayland run the following
 
-```text
+```bash
 MACHINE=freedom-u540 bitbake core-image-weston
 ```
 
 To build an image to run on the BeagleV using Wayland run the following
-```text
+
+```bash
 MACHINE=beaglev-starlight-jh7100 bitbake core-image-weston
 ```
 
 To build an image to run on the MangoPi MQ Pro (console only has been tested so far) run the following:
-```text
+
+```bash
 MACHINE=mangopi-mq-pro bitbake core-image-base
 ```
 
@@ -157,13 +182,13 @@ To build a full GUI equipped image running Plasma Mobile see the in-tree documen
 
 Run the 64-bit machine in QEMU using the following command:
 
-```text
+```bash
 MACHINE=qemuriscv64 runqemu nographic
 ```
 
 Run the 32-bit machine in QEMU using the following command:
 
-```text
+```bash
 MACHINE=qemuriscv32 runqemu nographic
 ```
 
@@ -173,7 +198,7 @@ MACHINE=qemuriscv32 runqemu nographic
 
 If you would like to boot the images from a TFTP server (optional) you should set your TFTP server address in your local.conf with the following line. Change ```127.0.0.1``` to the IP address of your TFTP server and copy the uImage to the server.
 
-```text
+```bash
 TFTP_SERVER_IP = "127.0.0.1"
 ```
 
@@ -181,7 +206,7 @@ TFTP_SERVER_IP = "127.0.0.1"
 
 To use the Microsemi expansion board with your HiFive Unleased add the following line to your local.conf. This tells the Unleashed to use a device tree with the PCIe device described:
 
-```text
+```bash
 RISCV_SBI_FDT:freedom-u540 = "hifive-unleashed-a00-microsemi.dtb"
 ```
 
@@ -189,23 +214,24 @@ RISCV_SBI_FDT:freedom-u540 = "hifive-unleashed-a00-microsemi.dtb"
 
 The output of the build can also be written to an SD card using bmaptool, the steps to do this are below:
 
-```text
-$ MACHINE=freedom-u540 wic create freedom-u540-opensbi -e core-image-minimal
-$ bmaptool create ./freedom-u540-opensbi-201812181337-mmcblk.direct > image.bmap
-$ sudo bmaptool copy --bmap image.bmap ./freedom-u540-opensbi-201812181337-mmcblk.direct /dev/sdX
+```bash
+MACHINE=freedom-u540 wic create freedom-u540-opensbi -e core-image-minimal
+bmaptool create ./freedom-u540-opensbi-201812181337-mmcblk.direct > image.bmap
+sudo bmaptool copy --bmap image.bmap ./freedom-u540-opensbi-201812181337-mmcblk.direct /dev/sdX
 ```
 
 ### dding wic.gz
 
 The output of a ```freedom-u540```, ```beaglev-starlight-jh7100``` or ```mangopi-mq-pro```  build will be a ```<image>.wic.gz``` file. You can write this file to an sd card using:
 
-```text
-$ zcat <image>-<machine>.wic.gz | sudo dd of=/dev/sdX bs=4M iflag=fullblock oflag=direct conv=fsync status=progress
+```bash
+zcat <image>-<machine>.wic.gz | sudo dd of=/dev/sdX bs=4M iflag=fullblock oflag=direct conv=fsync status=progress
 ```
 
 ### Using bmaptoop to write the image
 
 Instead of dding wic.gz image ```bmaptool``` (available in most Linux distributions and/or pip) can be used for more reliable and faster flashing. You can write this file to an sd card using:
-```text
-$ sudo bmaptool copy <image>-<machine>.wic.gz /dev/sdX
+
+```bash
+sudo bmaptool copy <image>-<machine>.wic.gz /dev/sdX
 ```


### PR DESCRIPTION
The current QUICK_START.md lists four sections (bitbake-setup, repo, envsetup.sh, kas) without explaining how they relate to each other. New users reading the doc have to figure out on their own that:

- bitbake-setup and repo+envsetup.sh are two alternative ways to prepare
  the same bitbake build environment
- kas is a standalone approach that replaces both setup and build steps
- the Build Images / Running sections apply after the environment is
  ready

This patch restructures the doc into three clearly labeled paths (A, B, C) with a brief overview upfront explaining the relationship between them. 

Also fix several warnings reported by markdownlint.

Signed-off-by: gsh1209 <gsh1209@outlook.com>