### PR TITLE
milkv-duo-fsbl: add dependency on bootloader

### DIFF
--- a/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
+++ b/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
@@ -14,7 +14,7 @@ B = "${S}/build"
 TARGET_LDFLAGS = ""
 SECURITY_LDFLAGS = ""
 
-do_compile[depends] += "opensbi:do_deploy"
+do_compile[depends] += "opensbi:do_deploy virtual/bootloader:do_deploy"
 
 do_compile () {
 	unset LDFLAGS


### PR DESCRIPTION
The recipe uses uses an artifact deployed by the bootloader. Add a dependency so that the artifact exist and milkv-duo-fsbl is rebuilt if the bootloader is changed.
