### PR TITLE
linux-starfive-dev: visonfive2: fix build with gcc16

### DIFF
--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -44,6 +44,8 @@ SRC_URI:jh7110 = " \
            file://0001-gcc-plugins-Rename-last_stmt-for-GCC-14.patch \
            file://0001-eswin-Repace-NULL-with-0-where-it-is-converted-from-.patch \
            file://0001-kbuild-Do-not-use-NOTIMMEDIATE.patch \
+           file://0001-gcc-plugins-Always-define-CONST_CAST_GIMPLE-and-CONS.patch \
+           file://0001-drm-img-rogue-fix-build-with-gcc-16.patch \
            file://visionfive2-graphics.cfg \
            file://modules.cfg \
 "

--- a/recipes-kernel/linux/linux-starfive/0001-drm-img-rogue-fix-build-with-gcc-16.patch
+++ b/recipes-kernel/linux/linux-starfive/0001-drm-img-rogue-fix-build-with-gcc-16.patch
@@ -1,0 +1,111 @@
+From 87de7d84b158d8e2eedada246025b8f96e99dd1d Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.oss.09@gmail.com>
+Date: Sat, 30 May 2026 11:21:19 +0000
+Subject: [PATCH] drm/img-rogue: fix build with gcc 16
+
+GCC 16 now complains about initialized/assigned but unused variables.
+Only define/set them if the relevant defines are set.
+
+Fixes:
+mmu_common.c:3038:20: error: variable 'ui32MappedCount' set but not used [-Werror=unused-but-set-variable=]
+ 3038 |         IMG_UINT32 ui32MappedCount = 0;
+
+sync_checkpoint.c:3094:40: error: variable 'ui32NullScpCount' set but not used [-Werror=unused-but-set-variable=]
+ 3094 |         IMG_UINT32 ui32ItemsFreed = 0, ui32NullScpCount = 0, __maybe_unused ui32PoolCount;
+
+rgxhwperf_common.c:3503:41: error: variable 'ui32TlPackets' set but not used [-Werror=unused-but-set-variable=]
+ 3503 |         IMG_UINT32                      ui32TlPackets = 0;
+
+Upstream-Status: Submitted [https://github.com/starfive-tech/linux/pull/149]
+Signed-off-by: Max Krummenacher <max.oss.09@gmail.com>
+---
+ .../drm/img/img-rogue/services/server/common/mmu_common.c  | 4 ++++
+ .../img/img-rogue/services/server/common/sync_checkpoint.c | 7 ++++++-
+ .../img-rogue/services/server/devices/rgxhwperf_common.c   | 6 ++++++
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/img/img-rogue/services/server/common/mmu_common.c b/drivers/gpu/drm/img/img-rogue/services/server/common/mmu_common.c
+index fb9c1c27f597..84d855ac9ce1 100644
+--- a/drivers/gpu/drm/img/img-rogue/services/server/common/mmu_common.c
++++ b/drivers/gpu/drm/img/img-rogue/services/server/common/mmu_common.c
+@@ -3035,7 +3035,9 @@ MMU_MapPages(MMU_CONTEXT *psMMUContext,
+ 	IMG_UINT32 uiPTEIndex = 0;
+ 	IMG_UINT32 uiPageSize = (1 << uiLog2HeapPageSize);
+ 	IMG_UINT32 uiLoop = 0;
++#if defined(PDUMP)
+ 	IMG_UINT32 ui32MappedCount = 0;
++#endif /*PDUMP*/
+ 	IMG_DEVMEM_OFFSET_T uiPgOffset = 0;
+ 	IMG_UINT32 uiFlushEnd = 0, uiFlushStart = 0;
+ 
+@@ -3333,7 +3335,9 @@ MMU_MapPages(MMU_CONTEXT *psMMUContext,
+ 						sDevVAddr.uiAddr,
+ 						uiPgOffset * uiPageSize));
+ 
++#if defined(PDUMP)
+ 				ui32MappedCount++;
++#endif /*PDUMP*/
+ 			}
+ 		}
+ 
+diff --git a/drivers/gpu/drm/img/img-rogue/services/server/common/sync_checkpoint.c b/drivers/gpu/drm/img/img-rogue/services/server/common/sync_checkpoint.c
+index 8f89f9c05a1e..98e5b40090c2 100644
+--- a/drivers/gpu/drm/img/img-rogue/services/server/common/sync_checkpoint.c
++++ b/drivers/gpu/drm/img/img-rogue/services/server/common/sync_checkpoint.c
+@@ -3091,7 +3091,10 @@ static IMG_UINT32 _CleanCheckpointPool(_SYNC_CHECKPOINT_CONTEXT *psContext)
+ 	DECLARE_DLLIST(sCleanupList);
+ 	DLLIST_NODE *psThis, *psNext;
+ 	OS_SPINLOCK_FLAGS uiFlags;
+-	IMG_UINT32 ui32ItemsFreed = 0, ui32NullScpCount = 0, __maybe_unused ui32PoolCount;
++	IMG_UINT32 ui32ItemsFreed = 0, __maybe_unused ui32PoolCount;
++#if (ENABLE_SYNC_CHECKPOINT_POOL_DEBUG == 1)
++	IMG_UINT32 ui32NullScpCount = 0;
++#endif
+ 
+ 	/* Acquire sync checkpoint pool lock */
+ 	OSSpinLockAcquire(psCtxCtl->hSyncCheckpointPoolLock, uiFlags);
+@@ -3116,10 +3119,12 @@ static IMG_UINT32 _CleanCheckpointPool(_SYNC_CHECKPOINT_CONTEXT *psContext)
+ 			 * from the list so it's safe to use sListNode here */
+ 			dllist_add_to_head(&sCleanupList, &psCheckpoint->sListNode);
+ 		}
++#if (ENABLE_SYNC_CHECKPOINT_POOL_DEBUG == 1)
+ 		else
+ 		{
+ 			ui32NullScpCount++;
+ 		}
++#endif
+ 	}
+ 
+ 	/* Release sync checkpoint pool lock */
+diff --git a/drivers/gpu/drm/img/img-rogue/services/server/devices/rgxhwperf_common.c b/drivers/gpu/drm/img/img-rogue/services/server/devices/rgxhwperf_common.c
+index 91f8471f8c4b..17b33adb4d0c 100644
+--- a/drivers/gpu/drm/img/img-rogue/services/server/devices/rgxhwperf_common.c
++++ b/drivers/gpu/drm/img/img-rogue/services/server/devices/rgxhwperf_common.c
+@@ -3500,7 +3500,9 @@ PVRSRV_ERROR RGXHWPerfAcquireEvents(
+ 	PVRSRV_ERROR			eError;
+ 	RGX_KM_HWPERF_DEVDATA*	psDevData = (RGX_KM_HWPERF_DEVDATA*)hDevData;
+ 	IMG_PBYTE				pDataDest;
++#if defined(DEBUG) || defined(DOXYGEN)
+ 	IMG_UINT32			ui32TlPackets = 0;
++#endif
+ 	IMG_PBYTE			pBufferEnd;
+ 	PVRSRVTL_PPACKETHDR psHDRptr;
+ 	PVRSRVTL_PACKETTYPE ui16TlType;
+@@ -3578,10 +3580,14 @@ PVRSRV_ERROR RGXHWPerfAcquireEvents(
+ 		psHDRptr = GET_NEXT_PACKET_ADDR(psHDRptr);
+ 		/* Updated to keep track of the next packet to be read. */
+ 		psDevData->pTlBufRead[eStreamId] = (IMG_PBYTE) ((void *)psHDRptr);
++#if defined(DEBUG) || defined(DOXYGEN)
+ 		ui32TlPackets++;
++#endif
+ 	}
+ 
++#if defined(DEBUG) || defined(DOXYGEN)
+ 	PVR_DPF((PVR_DBG_VERBOSE, "RGXHWPerfAcquireEvents: TL Packets processed %03d", ui32TlPackets));
++#endif
+ 
+ 	psDevData->bRelease[eStreamId] = IMG_FALSE;
+ 	if (psHDRptr >= (PVRSRVTL_PPACKETHDR)((void *)pBufferEnd))
+-- 
+2.54.0
+

--- a/recipes-kernel/linux/linux-starfive/0001-gcc-plugins-Always-define-CONST_CAST_GIMPLE-and-CONS.patch
+++ b/recipes-kernel/linux/linux-starfive/0001-gcc-plugins-Always-define-CONST_CAST_GIMPLE-and-CONS.patch
@@ -1,0 +1,43 @@
+From 34266f34dae5a5f768df6b13cd5718b589c41c73 Mon Sep 17 00:00:00 2001
+From: Kees Cook <kees@kernel.org>
+Date: Sat, 14 Mar 2026 14:24:56 +0100
+Subject: [PATCH] gcc-plugins: Always define CONST_CAST_GIMPLE and
+ CONST_CAST_TREE
+
+For gcc-16, the CONST_CAST macro family was removed. Add back what
+we were using in gcc-common.h, as they are simple wrappers.
+
+See GCC commits:
+  c3d96ff9e916c02584aa081f03ab999292efbb50
+  458c7926d48959abcb2c1adaa22458e27459a551
+
+Upstream-Status: Backport [905c559e51497b8bfdbb68df8be56d2f70f0de8e]
+
+Suggested-by: Ingo Saitz <ingo@hannover.ccc.de>
+Link: https://lore.kernel.org/lkml/ab6OKoay0OWkywjK@spatz.zoo
+Fixes: 6b90bd4ba40b ("GCC plugin infrastructure")
+Tested-by: Ivan Bulatovic <combuster@archlinux.us>
+Tested-by: Christopher Cradock <christopher@cradock.myzen.co.uk>
+Signed-off-by: Kees Cook <kees@kernel.org>
+---
+ scripts/gcc-plugins/gcc-common.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/gcc-plugins/gcc-common.h b/scripts/gcc-plugins/gcc-common.h
+index ceb119621001..abf9a30761f2 100644
+--- a/scripts/gcc-plugins/gcc-common.h
++++ b/scripts/gcc-plugins/gcc-common.h
+@@ -299,7 +299,9 @@ typedef const gimple *const_gimple_ptr;
+ #define gimple gimple_ptr
+ #define const_gimple const_gimple_ptr
+ #undef CONST_CAST_GIMPLE
+-#define CONST_CAST_GIMPLE(X) CONST_CAST(gimple, (X))
++#define CONST_CAST_GIMPLE(X) const_cast<gimple>((X))
++#undef CONST_CAST_TREE
++#define CONST_CAST_TREE(X) const_cast<tree>((X))
+ #endif
+ 
+ /* gimple related */
+-- 
+2.51.0
+


### PR DESCRIPTION
Backport a patch from mainline linux and fix the img-rogue driver.
