### PR TITLE
u-boot-starfive_v2021.10: Fixup build with newer GCC

### DIFF
--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.10.bb
@@ -20,6 +20,9 @@ DEPENDS:append = " u-boot-tools-native"
 
 DEPENDS:append = " jh7110-spl-tool-native"
 
+EXTRA_OEMAKE += 'KCFLAGS=-Wno-error=int-conversion'
+EXTRA_OEMAKE += 'HOSTCFLAGS=-Wno-error=int-conversion'
+
 # Overwrite this for your server
 TFTP_SERVER_IP ?= "127.0.0.1"
 


### PR DESCRIPTION
u-boot passes `unsigned long` values to some `void __iomem *` addresses resulting in build failures. Let's treat them as warnings insted of errors to avoid breakage on newer GCC versions.