### PR TITLE
kas: fix include paths

### DIFF
--- a/kas/ae350-ax45mp.yml
+++ b/kas/ae350-ax45mp.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: ae350-ax45mp

--- a/kas/bananapi-cm6-io.yml
+++ b/kas/bananapi-cm6-io.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: bananapi-cm6-io

--- a/kas/bananapi-f3.yml
+++ b/kas/bananapi-f3.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: bananapi-f3

--- a/kas/base-riscv.yml
+++ b/kas/base-riscv.yml
@@ -1,8 +1,8 @@
 header:
   version: 20
   includes:
-    - include/local.yml
-    - include/oe.yml
+    - kas/include/local.yml
+    - kas/include/oe.yml
 
 machine: qemuriscv64
 distro: poky-altcfg

--- a/kas/beaglev-ahead.yml
+++ b/kas/beaglev-ahead.yml
@@ -1,7 +1,7 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: beaglev-ahead
 target: core-image-minimal

--- a/kas/beaglev.yml
+++ b/kas/beaglev.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: beaglev-starlight-jh7100

--- a/kas/eswin-ebc77-mainline.yml
+++ b/kas/eswin-ebc77-mainline.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: eswin-ebc77-mainline

--- a/kas/eswin-ebc77.yml
+++ b/kas/eswin-ebc77.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: eswin-ebc77

--- a/kas/milkv-duo.yml
+++ b/kas/milkv-duo.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: milkv-duo 

--- a/kas/nezha.yml
+++ b/kas/nezha.yml
@@ -1,7 +1,7 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: nezha-allwinner-d1
 target: core-image-minimal

--- a/kas/orangepi-r2s.yml
+++ b/kas/orangepi-r2s.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: orangepi-r2s

--- a/kas/orangepi-rv2-mainline.yml
+++ b/kas/orangepi-rv2-mainline.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: orangepi-rv2-mainline

--- a/kas/orangepi-rv2.yml
+++ b/kas/orangepi-rv2.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: orangepi-rv2

--- a/kas/qemuriscv64.yml
+++ b/kas/qemuriscv64.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: qemuriscv64

--- a/kas/start64.yml
+++ b/kas/start64.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: star64

--- a/kas/visionfive.yml
+++ b/kas/visionfive.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: visionfive

--- a/kas/visionfive2.yml
+++ b/kas/visionfive2.yml
@@ -1,6 +1,6 @@
 header:
   version: 20
   includes:
-    - base-riscv.yml
+    - kas/base-riscv.yml
 
 machine: visionfive2


### PR DESCRIPTION
Current versions of Kas now what includes with relative paths to be relative to the "repositories base directory", as documented on https://kas.readthedocs.io/en/5.2/userguide/project-configuration.html

Otherwise, we fall back to an older mode, looking for includes in a path relative to the including kas file, but we're getting such warnings:

2026-06-11 07:56:02 - INFO - run-kas 5.0 started
2026-06-11 07:56:02 - WARNING - Falling back to file-relative addressing of local include "base-riscv.yml" 2026-06-11 07:56:02 - WARNING - Update your layer to repo-relative addressing to avoid this warning 2026-06-11 07:56:02 - WARNING - Falling back to file-relative addressing of local include "include/local.yml" 2026-06-11 07:56:02 - WARNING - Update your layer to repo-relative addressing to avoid this warning 2026-06-11 07:56:02 - WARNING - Falling back to file-relative addressing of local include "include/oe.yml" 2026-06-11 07:56:02 - WARNING - Update your layer to repo-relative addressing to avoid this warning