### PR TITLE
machine: add visionfive2-mainline

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This layer depends on:
 | star64                   | [PINE64 STAR64](https://pine64.org/devices/star64/)                                                          | 5.15 Kernel [fork](https://github.com/fishwaldo/Star64_linux)                    |
 | visionfive               | StarFive VisionFive                                                                                          | No product page found                                                            |
 | visionfive2              | [StarFive VisionFive 2](https://www.starfivetech.com/en/index.php?s=hardware&c=show&id=14)                   |                                                                                  |
+| visionfive2-mainline     | [StarFive VisionFive 2](https://www.starfivetech.com/en/index.php?s=hardware&c=show&id=14)                   | Mainline Kernel and U-Boot                                                       |
 
 Note that this layer also provides improvements and features for the
 upstream qemuriscv32 and qemuriscv64 machines.

--- a/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json
+++ b/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json
@@ -56,7 +56,8 @@
                         { "name": "machine/orangepi-rv2", "description": "OrangePi RV2 (Vendor Kernel)" },
                         { "name": "machine/orangepi-rv2-mainline", "description": "OrangePi RV2 (Mainline Kernel)" },
                         { "name": "machine/star64", "description": "PINE64 Star64" },
-                        { "name": "machine/visionfive2", "description": "x86_64 (64-bit) PCs and servers" }
+                        { "name": "machine/visionfive2", "description": "x86_64 (64-bit) PCs and servers" },
+                        { "name": "machine/visionfive2-mainline", "description": "Visionfive2 (Mainline Kernel)" }
                     ]
                 }
             }

--- a/conf/machine/include/jh7110-common.inc
+++ b/conf/machine/include/jh7110-common.inc
@@ -5,38 +5,6 @@
 
 require jh7110.inc
 
-#============================================
-# Common Preferred Providers
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-starfive-dev"
-PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-starfive"
-PREFERRED_PROVIDER_virtual/libgl ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/libglx ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/mesa ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/libgbm ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/egl ?= "mesa-pvr"
-PREFERRED_PROVIDER_virtual/libgles3 ?= "visionfive2-pvr-graphics"
-PREFERRED_PROVIDER_virtual/libgles1 ?= "visionfive2-pvr-graphics"
-PREFERRED_PROVIDER_virtual/libgles2 ?= "visionfive2-pvr-graphics"
-PREFERRED_PROVIDER_virtual/libomxil ?= "libsf-omxil"
-#============================================
-
-#============================================
-# Common Machine Configuration
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    kernel-modules \
-    linux-firmware-visionfive2-imggpu \
-    vdec-module \
-    venc-module \
-    jpu-module \
-    visionfive2-pvr-graphics-tools \
-"
-#============================================
-
-#============================================
-# Common Kernel Configuration
-KERNEL_MODULE_AUTOLOAD += "pvrsrvkm"
-#============================================
-
 # opensbi config
 RISCV_SBI_FW_TEXT_START = "0x40000000"
 

--- a/conf/machine/include/jh7110-vendor.inc
+++ b/conf/machine/include/jh7110-vendor.inc
@@ -1,0 +1,34 @@
+#@TYPE: SOC
+#@NAME: StarFive JH7110
+#@SOC: StarFive JH7110
+
+#============================================
+# Common Preferred Providers
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-starfive-dev"
+PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-starfive"
+PREFERRED_PROVIDER_virtual/libgl ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/libglx ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/mesa ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/libgbm ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/egl ?= "mesa-pvr"
+PREFERRED_PROVIDER_virtual/libgles3 ?= "visionfive2-pvr-graphics"
+PREFERRED_PROVIDER_virtual/libgles1 ?= "visionfive2-pvr-graphics"
+PREFERRED_PROVIDER_virtual/libgles2 ?= "visionfive2-pvr-graphics"
+PREFERRED_PROVIDER_virtual/libomxil ?= "libsf-omxil"
+#============================================
+
+#============================================
+# Common Machine Configuration
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    linux-firmware-visionfive2-imggpu \
+    vdec-module \
+    venc-module \
+    jpu-module \
+    visionfive2-pvr-graphics-tools \
+"
+#============================================
+
+#============================================
+# Common Kernel Configuration
+KERNEL_MODULE_AUTOLOAD += "pvrsrvkm"
+#============================================

--- a/conf/machine/include/visionfive2-common.inc
+++ b/conf/machine/include/visionfive2-common.inc
@@ -1,0 +1,39 @@
+#@TYPE: Include
+#@NAME: visionfive2-common
+#@DESCRIPTION: Common configuration for VisionFive 2 boards
+
+require jh7110-common.inc
+
+#============================================
+# Common Machine Configuration
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    kernel-modules \
+		"
+#============================================
+
+MACHINE_FEATURES += "efi"
+
+#============================================
+# SBI Configuration
+RISCV_SBI_FDT ?= "jh7110-starfive-visionfive-2-v1.3b.dtb"
+unset RISCV_SBI_PAYLOAD
+#============================================
+
+#============================================
+# Kernel Configuration
+KERNEL_DEVICETREE ?= "starfive/jh7110-starfive-visionfive-2-v1.3b.dtb"
+KERNEL_CLASSES = "kernel"
+KERNEL_IMAGETYPE = "Image"
+#============================================
+
+#============================================
+# Uboot Configuration
+UBOOT_DTB = ""
+UBOOT_SUFFIX = "itb"
+UBOOT_MACHINE = "starfive_visionfive2_defconfig"
+UBOOT_DTB_BINARY = "jh7110-starfive-visionfive-2.dtb"
+SPL_BINARY = "spl/u-boot-spl.bin.normal.out"
+UBOOT_ENV = ""
+#============================================
+
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot"

--- a/conf/machine/visionfive2-mainline.conf
+++ b/conf/machine/visionfive2-mainline.conf
@@ -1,0 +1,8 @@
+#@TYPE: Machine
+#@NAME: visionfive2-mainline
+#@SOC: StarFive JH7110
+#@DESCRIPTION: Machine configuration for the VisionFive 2 board with mainline Linux and U-Boot
+
+require include/visionfive2-common.inc
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-mainline"

--- a/conf/machine/visionfive2.conf
+++ b/conf/machine/visionfive2.conf
@@ -3,30 +3,6 @@
 #@SOC: StarFive JH7110
 #@DESCRIPTION: Machine configuration for the VisionFive 2 board
 
-require include/jh7110-common.inc
+require include/jh7110-vendor.inc
+require include/visionfive2-common.inc
 
-MACHINE_FEATURES += "efi"
-
-#============================================
-# SBI Configuration
-RISCV_SBI_FDT ?= "jh7110-starfive-visionfive-2-v1.3b.dtb"
-unset RISCV_SBI_PAYLOAD
-#============================================
-
-#============================================
-# Kernel Configuration
-KERNEL_DEVICETREE ?= "starfive/jh7110-starfive-visionfive-2-v1.3b.dtb"
-KERNEL_CLASSES = "kernel"
-KERNEL_IMAGETYPE = "Image"
-#============================================
-
-#============================================
-# Uboot Configuration
-UBOOT_DTB = ""
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
-UBOOT_SUFFIX = "itb"
-UBOOT_MACHINE = "starfive_visionfive2_defconfig"
-UBOOT_DTB_BINARY = "jh7110-starfive-visionfive-2.dtb"
-SPL_BINARY = "spl/u-boot-spl.bin.normal.out"
-UBOOT_ENV = ""
-#============================================

--- a/kas/visionfive2-mainline.yml
+++ b/kas/visionfive2-mainline.yml
@@ -1,0 +1,6 @@
+header:
+  version: 20
+  includes:
+    - base-riscv.yml
+
+machine: visionfive2-mainline

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -98,6 +98,10 @@ do_compile:prepend:visionfive2() {
     export OPENSBI=${DEPLOY_DIR_IMAGE}/fw_dynamic.bin
 }
 
+do_compile:prepend:visionfive2-mainline() {
+    export OPENSBI=${DEPLOY_DIR_IMAGE}/fw_dynamic.bin
+}
+
 #############################
 # deploy task customizations
 #############################

--- a/recipes-kernel/linux/linux-mainline-common.inc
+++ b/recipes-kernel/linux/linux-mainline-common.inc
@@ -15,11 +15,12 @@ KCONFIG_MODE = "--alldefconfig"
 KBUILD_DEFCONFIG ?= "defconfig"
 KBUILD_DEFCONFIG:qemuriscv32 = "rv32_defconfig"
 
-COMPATIBLE_MACHINE = "(qemuriscv32|qemuriscv64|freedom-u540)"
+COMPATIBLE_MACHINE = "(qemuriscv32|qemuriscv64|freedom-u540|visionfive2-mainline)"
 
 KERNEL_FEATURES:remove = "features/debug/printk.scc"
 KERNEL_FEATURES:remove = "features/kernel-sample/kernel-sample.scc"
 KERNEL_FEATURES:remove = "features/taskstats/taskstats.scc"
+KERNEL_FEATURES:remove = "cfg/efi.scc"
 KERNEL_FEATURES:remove = "cfg/fs/vfat.scc"
 KERNEL_FEATURES:remove:riscv32 = " ${KERNEL_FEATURES_RISCV}"
 KERNEL_FEATURES:remove:riscv64 = " ${KERNEL_FEATURES_RISCV}"


### PR DESCRIPTION
This adds support for booting the upstream Linux kernel and U-Boot on the StarFive VisionFive 2 (and Milk-V Mars)

At this stage the board boots to the Linux console, support for components that require non-upstream drivers is currently not included.

This adds the machine includes visionfive2-common.inc and jh7110-vendor.inc to avoid mostly redundant configurations for the visionfive2 and the visionfive2-mainline boards.

The new kernel recipe linux-mainline-jh7110.bb has been added for boards based on the StarFive JH-7110 SoC.

Testing involved building core-images for visionfive2-mainline and visionfive2 and booting them on a Milk-V Mars board. It has been confirmed that the variables that specify the Linux kernel and U-Boot configuration for the existing visionfive2 board were not altered by the consolidation of the visionfive2/jh7110 configuration.

Signed-off-by: Matthias Kaehlcke <matthias@kaehlcke.net>
