### PR TITLE
meta-riscv: cleanup README, bitbake-setup templates; rework PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,25 @@
-<!--
-Please make sure you've read and understood our contributing guidelines.
+# Description
 
-For additional information on the contribution guidelines:
-https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information
+Summarize the changes made, your motivation, and include any linkage to issues
+or other PRs here. Use "fixes #xxxx" for fixes and "connected to #xxxx" for
+linked issues.
 
-If this PR fixes an issue, make sure your description includes "fixes #xxxx".
+## Checklist
 
-If this PR connects to an issue, make sure your description includes "connected to #xxxx".
+- [ ] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
+- [ ] I have tested this change (provide brief details below)
+- [ ] Documentation has been added/updated where necessary in the README and `docs/`
+- [ ] If the change is to a BSP in
+  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
+  then it is maintenance-only, i.e. it does not add support for a
+  previously-removed BSP (or significant features to one slated for removal)
+- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
+- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
+  have been updated, if necessary
+- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
+- [ ] I have added my `Signed-off-by` and any other tags to each commit
 
-If you are adding a new BSP, please review the DEPRECATED.md file to confirm
-that it has not previously been removed. If you are modifying an existing BSP
-which is slated for removal in an upcoming release, consider whether the changes
-are necessary before that occurs. If needed, open a new issue or discussion.
+# How has this been tested?
 
-Please provide the following information:
--->
-
-**- <recipename>: Short log / Statement of what needed to be changed.**
-  
-**-(Optional pointers to external resources, such as defect tracking)**
-  
-**-The intent of your change.**
-  
-**-(Optional, if it's not clear from above) how your change resolves the
-issues in the first part.**
-
-**-(Optional, if you have added a new BSP) indicate which new platforms are
-supported with this change by adding a new row in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines).**
-  
-**-Tag line(s) at the end.**
-
-**-Signed-off-by: Random J Developer <random@developer.example.org>**
-
+Provide a brief summary here (e.g. build only, build + boot test, something more
+specific). Boot logs, images, or other artifacts are especially helpful.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This layer depends on:
 
 | MACHINE                  | Platform                                                                                                     | Notes                                                                            |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| ae350-ax45mp             | [Andes AX45MP](https://www.andestech.com/en/products-solutions/andescore-processors/riscv-ax45mp/)           |                                                                                  |
 | bananapi-f3              | [BPI-F3](https://docs.banana-pi.org/en/BPI-F3/BananaPi_BPI-F3)                                               | Mainline Kernel and U-Boot (uses vendor FSBL)                                    |
 | bananapi-cm6-io          | [BPI-CM6](https://docs.banana-pi.org/en/BPI-CM6/BananaPi_BPI-CM6)                                            | Mainline Kernel and U-Boot (uses vendor FSBL)                                    |
 | beaglev-ahead            | [BeagleV-Ahead](https://www.beagleboard.org/boards/beaglev-ahead)                                            |                                                                                  |

--- a/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json
+++ b/bitbake-registry/meta-riscv-oe-nodistro-master.conf.json
@@ -42,9 +42,12 @@
                 "machine": {
                     "description": "Target machines",
                     "options" : [
+                        { "name": "machine/ae350-ax45mp", "description": "Andes AE350 ax45mp" },
+                        { "name": "machine/bananapi-cm6-io", "description": "BananaPi CM6 IO" },
                         { "name": "machine/bananapi-f3", "description": "BananaPi BPI-F3" },
                         { "name": "machine/beaglev-ahead", "description": "BeagleV Ahead" },
                         { "name": "machine/beaglev-starlight-jh7100", "description": "BeagleV" },
+                        { "name": "machine/dc-roma-fml13v01", "description": "DeepComputing DC-ROMA RISC-V Mainboard (FML13V01)" },
                         { "name": "machine/eswin-ebc77", "description": "ESWIN EBC77 (Vendor Kernel)" },
                         { "name": "machine/eswin-ebc77-mainline", "description": "ESWIN EBC77 (Mainline Kernel)" },
                         { "name": "machine/freedom-u540", "description": "Freedom U540" },
@@ -59,7 +62,7 @@
                         { "name": "machine/orangepi-rv2-mainline", "description": "OrangePi RV2 (Mainline Kernel)" },
                         { "name": "machine/star64", "description": "PINE64 Star64" },
                         { "name": "machine/visionfive", "description": "StarFive VisionFive" },
-                        { "name": "machine/visionfive2", "description": "x86_64 (64-bit) PCs and servers" }
+                        { "name": "machine/visionfive2", "description": "StarFive VisionFive 2" }
                     ]
                 }
             }

--- a/bitbake-registry/meta-riscv-poky-master.conf.json
+++ b/bitbake-registry/meta-riscv-poky-master.conf.json
@@ -47,9 +47,12 @@
                 "machine": {
                     "description": "Target machines",
                     "options" : [
+                        { "name": "machine/ae350-ax45mp", "description": "Andes AE350 ax45mp" },
+                        { "name": "machine/bananapi-cm6-io", "description": "BananaPi CM6 IO" },
                         { "name": "machine/bananapi-f3", "description": "BananaPi BPI-F3" },
                         { "name": "machine/beaglev-ahead", "description": "BeagleV Ahead" },
                         { "name": "machine/beaglev-starlight-jh7100", "description": "BeagleV" },
+                        { "name": "machine/dc-roma-fml13v01", "description": "DeepComputing DC-ROMA RISC-V Mainboard (FML13V01)" },
                         { "name": "machine/eswin-ebc77", "description": "ESWIN EBC77 (Vendor Kernel)" },
                         { "name": "machine/eswin-ebc77-mainline", "description": "ESWIN EBC77 (Mainline Kernel)" },
                         { "name": "machine/freedom-u540", "description": "Freedom U540" },
@@ -64,7 +67,7 @@
                         { "name": "machine/orangepi-rv2-mainline", "description": "OrangePi RV2 (Mainline Kernel)" },
                         { "name": "machine/star64", "description": "PINE64 Star64" },
                         { "name": "machine/visionfive", "description": "StarFive VisionFive" },
-                        { "name": "machine/visionfive2", "description": "x86_64 (64-bit) PCs and servers" }
+                        { "name": "machine/visionfive2", "description": "StarFive VisionFive 2" }
                     ]
                 },
                 "distro": {


### PR DESCRIPTION
I realized while reworking my build environment that there were a few issues in the README and existing bitbake-setup templates:

- The `ae350-ax45mp` BSP isn't in the README or the bitbake-setup templates
- The `bananapi-cm6-io` and `dc-roma-fml13v01` BSPs aren't in the bitbake-setup templates either
- the `visionfive2` BSP in the bitbake-setup templates still incorrectly mentions x86_64 hardware in its description (the template was based on the core layer ones, and this is something I failed to change during the initial submission)

This made me think about adding some extra guidance for contributors (including myself) so that all BSPs get the same level of coverage in the layer. To achieve this, I've modified the `.github/PULL_REQUEST_TEMPLATE.md` file to incorporate a submission checklist covering the categories we currently go through in a simpler way, and also updated the docs linkage for contributor guidelines (the old link takes you to the Yocto wiki, which redirects you to the OpenEmbedded wiki, which finally points you to the actual docs on `docs.yoctoproject.org`).

If we want to spend more time reviewing the format and content of the third patch, I can break it out into a separate PR/discussion.

Signed-off-by: Trevor Gamblin <tgamblin@baylibre.com>

