### PR TITLE
milkv-duo-fsbl: fix build with newer binutils

### DIFF
--- a/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
+++ b/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl.bb
@@ -4,7 +4,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Proprietary;md5=0557f9d92cf58f2
 
 inherit nopackages deploy
 
-SRC_URI = "git://github.com/milkv-duo/milkv-duo-buildroot-libraries;protocol=https;branch=main"
+SRC_URI = " \
+    git://github.com/milkv-duo/milkv-duo-buildroot-libraries;protocol=https;branch=main \
+    file://0001-milkv-duo-fsbl-fix-build-with-newer-binutils.patch;patchdir=${UNPACKDIR}/${BP} \
+"
 SRCREV = "f359994bd497f942bb67734280d81f6640c7c168"
 
 COMPATIBLE_MACHINE = "milkv-duo"

--- a/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl/0001-milkv-duo-fsbl-fix-build-with-newer-binutils.patch
+++ b/recipes-bsp/milkv-duo-fsbl/milkv-duo-fsbl/0001-milkv-duo-fsbl-fix-build-with-newer-binutils.patch
@@ -1,0 +1,34 @@
+From 26f3cbb8c0dfbf4f0fe759c142e0633394888181 Mon Sep 17 00:00:00 2001
+From: Max Krummenacher <max.oss.09@gmail.com>
+Date: Thu, 30 Jul 2026 13:39:11 +0000
+Subject: [PATCH] milkv-duo-fsbl: fix build with newer binutils
+
+With ld 2.47 building fails with the following error:
+
+|   LD      build/cv180x/bl2/bl2.elf
+| riscv64-tdx-linux-musl-ld -o build/cv180x/bl2/bl2.elf -Os --gc-sections   -Map=./build/cv180x/bl2/bl2.map --script ./build/cv180x/bl2/bl2.ld ./build/cv180x/bl2/build_message.o plat/cv180x/bl2_objs/cv1800b_milkv_duo_sd/bl2/*.o ./build/cv180x/bl2/bl2_main.o ./build/cv180x/bl2/bl2_entrypoint.o
+| .../riscv64-tdx-linux-musl-ld: -O requires a numerical argument or '-' or 'fast' or 'default'make: *** [Makefile:206: build/cv180x/bl2/bl2.elf] Error 1
+
+Drop the commandline option '-Os' and depend on the ld's default.
+
+Upstream-Status: Pending
+Signed-off-by: Max Krummenacher <max.oss.09@gmail.com>
+---
+ firmware/lib/cpu/riscv/cpu.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/firmware/lib/cpu/riscv/cpu.mk b/firmware/lib/cpu/riscv/cpu.mk
+index eab03601b77f..357acc347f9e 100644
+--- a/firmware/lib/cpu/riscv/cpu.mk
++++ b/firmware/lib/cpu/riscv/cpu.mk
+@@ -20,7 +20,6 @@ TF_CFLAGS += \
+ 	-fno-delete-null-pointer-checks
+ 
+ TF_LDFLAGS += \
+-	 -Os \
+ 	--gc-sections \
+ 	${TF_LDFLAGS_aarch64}
+ 
+-- 
+2.51.0
+


### PR DESCRIPTION
With ld 2.47 building fails with the following error:

|   LD      build/cv180x/bl2/bl2.elf
| riscv64-tdx-linux-musl-ld -o build/cv180x/bl2/bl2.elf -Os --gc-sections   -Map=./build/cv180x/bl2/bl2.map --script ./build/cv180x/bl2/bl2.ld ./build/cv180x/bl2/build_message.o plat/cv180x/bl2_objs/cv1800b_milkv_duo_sd/bl2/*.o ./build/cv180x/bl2/bl2_main.o ./build/cv180x/bl2/bl2_entrypoint.o
| .../riscv64-tdx-linux-musl-ld: -O requires a numerical argument or '-' or 'fast' or 'default'make: *** [Makefile:206: build/cv180x/bl2/bl2.elf] Error 1

Older ld seem to have silently ignored the undefined cmdline parameter -Os.

# How has this been tested?

A build of a simple image boots rom->fsbl->opensbi->u-boot. I.e. works as before on a milkV Duo.