### PR TITLE
Visionfive gcc15 fixes master

### DIFF
--- a/conf/machine/visionfive.conf
+++ b/conf/machine/visionfive.conf
@@ -30,6 +30,13 @@ IMAGE_BOOT_FILES:append = " \
     fw_payload.bin      \
     ${RISCV_SBI_FDT}    \
 "
+# The kernel's own devicetree must also be deployed and booted separately
+# from the U-Boot devicetree (RISCV_SBI_FDT / ${fdtcontroladdr}): the
+# U-Boot fork's DT only carries the legacy "riscv,isa" string, which
+# kernels >=6.9 refuse to parse into a valid hart, causing a smpboot BUG.
+# The kernel DT (built from mainline sources) has the modern
+# riscv,isa-base/riscv,isa-extensions properties instead.
+IMAGE_BOOT_FILES:append = " jh7100-starfive-visionfive-v1.dtb"
 #============================================
 
 #============================================

--- a/conf/machine/visionfive.conf
+++ b/conf/machine/visionfive.conf
@@ -18,6 +18,7 @@ RISCV_SBI_FDT ?= "jh7100-visionfive.dtb"
 
 #============================================
 # Kernel Configuration
+KERNEL_IMAGETYPE = "Image"
 KERNEL_DEVICETREE ?= "starfive/jh7100-starfive-visionfive-v1.dtb"
 #============================================
 

--- a/conf/machine/visionfive.conf
+++ b/conf/machine/visionfive.conf
@@ -38,6 +38,11 @@ UBOOT_ENTRYPOINT = "0x80200000"
 UBOOT_DTB_LOADADDRESS = "0x82200000"
 UBOOT_DTB = "1"
 UBOOT_DTB_BINARY = "jh7100-visionfive.dtb"
+# u-boot-starfive builds its own boot.scr.uimg from tftp-mmc-boot.txt in
+# do_configure:prepend/do_deploy:append; disable u-boot.inc's generic
+# UBOOT_ENV handling (which expects a boot.cmd this recipe never provides)
+# to avoid it, matching visionfive2.conf.
+UBOOT_ENV = ""
 #============================================
 
 #============================================

--- a/recipes-bsp/u-boot/u-boot-starfive/0002-cmd-misc-fix-incompatible-pointer-type-build-error.patch
+++ b/recipes-bsp/u-boot/u-boot-starfive/0002-cmd-misc-fix-incompatible-pointer-type-build-error.patch
@@ -1,0 +1,39 @@
+cmd: misc: fix incompatible-pointer-types build error with newer GCC
+
+misc_read() takes a "void *buf" and misc_write() takes a "const void *buf".
+Storing both behind a single "int (*)(struct udevice *, int, void *, int)"
+function pointer relies on an implicit qualification conversion that GCC
+14+ treats as a hard error by default (-Werror=incompatible-pointer-types),
+instead of the warning older GCC versions emitted. Call misc_read()/
+misc_write() directly instead of going through a common function pointer,
+matching the fix already applied upstream in mainline U-Boot.
+
+Upstream-Status: Backport [https://github.com/u-boot/u-boot/commit/c4645fc87e96e730a6c140d7d7820be2da1b2743]
+Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>
+
+Index: u-boot/cmd/misc.c
+===================================================================
+--- u-boot.orig/cmd/misc.c
++++ u-boot/cmd/misc.c
+@@ -44,7 +44,6 @@ static int do_misc_list(struct cmd_tbl
+ static int do_misc_op(struct cmd_tbl *cmdtp, int flag,
+ 		      int argc, char *const argv[], enum misc_op op)
+ {
+-	int (*misc_op)(struct udevice *, int, void *, int);
+ 	struct udevice *dev;
+ 	int offset;
+ 	void *buf;
+@@ -62,11 +61,9 @@ static int do_misc_op(struct cmd_tbl *c
+ 	size = hextoul(argv[3], NULL);
+
+ 	if (op == MISC_OP_READ)
+-		misc_op = misc_read;
++		ret = misc_read(dev, offset, buf, size);
+ 	else
+-		misc_op = misc_write;
+-
+-	ret = misc_op(dev, offset, buf, size);
++		ret = misc_write(dev, offset, buf, size);
+ 	if (ret < 0) {
+ 		if (ret == -ENOSYS) {
+ 			printf("The device does not support %s\n",

--- a/recipes-bsp/u-boot/u-boot-starfive/0003-configs-jh7100-visionfive-disable-unused-MACB-driver.patch
+++ b/recipes-bsp/u-boot/u-boot-starfive/0003-configs-jh7100-visionfive-disable-unused-MACB-driver.patch
@@ -1,0 +1,34 @@
+configs: starfive_jh7100_visionfive_smode: disable unused MACB driver
+
+CONFIG_SIFIVE_FU740=y is enabled for this target (arch/riscv/cpu/fu740/Kconfig),
+and it carries "imply MACB", pulling in the Cadence MACB/GEM ethernet driver
+(drivers/net/macb.c) even though the VisionFive V1 (JH7100) board does not use
+that IP block at all -- its Ethernet MAC is the Synopsys DesignWare GMAC,
+already enabled via CONFIG_ETH_DESIGNWARE=y.
+
+Because CONFIG_DM_ETH/CONFIG_CLK are off for this target, macb.c falls back to
+the legacy get_macb_pclk_rate() clock hook, which is only ever implemented for
+ARM AT91 boards (arch/arm/mach-at91/include/mach/clk.h) -- there's no jh7100
+implementation, only a placeholder header. That produces an
+implicit-function-declaration build error, which newer GCC (14+) treats as a
+hard error instead of a warning.
+
+Since MACB is not the driver this board actually uses, disable it instead of
+trying to implement a clock hook nothing calls.
+
+Upstream-Status: Inappropriate [board-specific Kconfig fix, not applicable
+upstream since the defconfig itself isn't in mainline U-Boot]
+Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>
+
+Index: u-boot/configs/starfive_jh7100_visionfive_smode_defconfig
+===================================================================
+--- u-boot.orig/configs/starfive_jh7100_visionfive_smode_defconfig
++++ u-boot/configs/starfive_jh7100_visionfive_smode_defconfig
+@@ -143,6 +143,7 @@ CONFIG_PHY_ADDR=3
+ # CONFIG_PHY_MSCC is not set
+ CONFIG_PHY_YUTAI=y
+ # CONFIG_DM_ETH is not set
++# CONFIG_MACB is not set
+ CONFIG_ETH_DESIGNWARE=y
+ CONFIG_RGMII=y
+ # CONFIG_MII is not set

--- a/recipes-bsp/u-boot/u-boot-starfive/uEnv-visionfive.txt
+++ b/recipes-bsp/u-boot/u-boot-starfive/uEnv-visionfive.txt
@@ -7,5 +7,4 @@ kernel_addr_r=0x84000000
 kernel_comp_addr_r=0x90000000
 kernel_cx_addr_r=0x88000000
 ramdisk_addr_r=0x88300000
-load mmc 0:1 0xa0000000 fitImage
-bootm 0xa0000000
+bootcmd=load mmc 0:1 ${kernel_addr_r} Image; load mmc 0:1 ${kernel_cx_addr_r} jh7100-starfive-visionfive-v1.dtb; booti ${kernel_addr_r} - ${kernel_cx_addr_r}

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
@@ -37,11 +37,12 @@ TFTP_SERVER_IP ?= "127.0.0.1"
 do_configure:prepend() {
     sed -i -e 's,@SERVERIP@,${TFTP_SERVER_IP},g' ${UNPACKDIR}/tftp-mmc-boot.txt
     mkimage -O linux -T script -C none -n "U-Boot boot script" \
-        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${UNPACKDIR}/${UBOOT_ENV_BINARY}
+        -d ${UNPACKDIR}/tftp-mmc-boot.txt ${UNPACKDIR}/boot.scr.uimg
 }
 
 do_deploy:append:visionfive() {
     install -m 644 ${UNPACKDIR}/uEnv-visionfive.txt ${DEPLOYDIR}/uEnv.txt
+    install -Dm 644 ${UNPACKDIR}/boot.scr.uimg ${DEPLOYDIR}/boot.scr.uimg
 }
 
 do_deploy:append:visionfive2() {

--- a/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
+++ b/recipes-bsp/u-boot/u-boot-starfive_v2021.04.bb
@@ -14,6 +14,8 @@ SRC_URI = "git://github.com/starfive-tech/u-boot.git;protocol=https;branch=${BRA
 
 SRC_URI:append:visionfive = " \
            file://fix-riscv-isa.patch \
+           file://0002-cmd-misc-fix-incompatible-pointer-type-build-error.patch \
+           file://0003-configs-jh7100-visionfive-disable-unused-MACB-driver.patch \
            file://uEnv-visionfive.txt \
 "
 SRC_URI:append:visionfive2 = " \

--- a/recipes-kernel/linux/linux-starfive-dev.bb
+++ b/recipes-kernel/linux/linux-starfive-dev.bb
@@ -11,6 +11,9 @@ SRCREV = "${AUTOREV}"
 # release JH7110_VF2_6.12_v6.0.0
 SRCREV:visionfive2 = "4cecf169f38eb94b40e307f5f870055e4d9d64f1"
 SRCREV:star64 = "e4c0928f1e42ed82ab9fa8918bc7094d3c0414d8"
+# tip of starfive-tech/linux visionfive branch as of 2026-07-15; pinned since
+# several local patches below only apply cleanly against this exact revision
+SRCREV:visionfive = "e0d906c0ce2d81cc429b4807a71c98f3e6f0253c"
 
 BRANCH = "branch=visionfive"
 BRANCH:visionfive2 = "branch=JH7110_VisionFive2_6.12.y_devel"
@@ -29,13 +32,23 @@ SRC_URI = "git://github.com/${FORK}/${REPO}.git;protocol=https;${BRANCH} \
            file://0001-riscv-fix-building-external-modules.patch \
            file://0001-gcc-plugins-Rename-last_stmt-for-GCC-14.patch \
            file://0001-eswin-Repace-NULL-with-0-where-it-is-converted-from-.patch \
-           file://0001-perf-cpumap-Make-counter-as-unsigned-ints.patch \
            file://modules.cfg \
           "
 
 SRC_URI:append:visionfive = " \
+           file://0001-perf-cpumap-Make-counter-as-unsigned-ints.patch \
            file://extra.cfg \
 "
+
+# Already merged into the starfive-tech/linux visionfive branch HEAD pinned
+# above (these backport patches' context no longer matches and they fail to
+# apply as-is), plus drivers/net/wireless/eswin, which is JH7110
+# (VisionFive2) hardware that doesn't exist in this JH7100 kernel tree at all.
+SRC_URI:remove:visionfive = "file://0001-gcc-plugins-Fix-build-for-upcoming-GCC-release.patch \
+                              file://0001-riscv-fix-building-external-modules.patch \
+                              file://0001-gcc-plugins-Rename-last_stmt-for-GCC-14.patch \
+                              file://0001-eswin-Repace-NULL-with-0-where-it-is-converted-from-.patch \
+                             "
 
 SRC_URI:jh7110 = " \
            git://github.com/${FORK}/${REPO}.git;protocol=https;${BRANCH} \

--- a/recipes-kernel/linux/linux-starfive/0001-perf-cpumap-Make-counter-as-unsigned-ints.patch
+++ b/recipes-kernel/linux/linux-starfive/0001-perf-cpumap-Make-counter-as-unsigned-ints.patch
@@ -1,7 +1,4 @@
-From d14450f9e0f05ea7177c5404a7a9289352caab77 Mon Sep 17 00:00:00 2001
-From: Khem Raj <raj.khem@gmail.com>
-Date: Mon, 23 Jan 2023 13:04:10 -0800
-Subject: [PATCH] perf cpumap: Make counter as unsigned ints
+perf cpumap: Make counter as unsigned ints
 
 These are loop counters which is inherently unsigned. Therefore make
 them unsigned. Moreover it also fixes alloc-size-larger-than
@@ -22,17 +19,21 @@ Cc: Alexander Shishkin <alexander.shishkin@linux.intel.com>
 Cc: Jiri Olsa <jolsa@kernel.org>
 Cc: Namhyung Kim <namhyung@kernel.org>
 
-Upstream-Status: Submitted [https://lore.kernel.org/linux-perf-users/20230123211310.127532-1-raj.khem@gmail.com/T/#u]
----
- tools/lib/perf/cpumap.c | 10 +++++-----
- 1 file changed, 5 insertions(+), 5 deletions(-)
+Refreshed against the current starfive-tech/linux visionfive branch HEAD
+(e0d906c0ce2d81cc429b4807a71c98f3e6f0253c), where tools/lib/perf/cpumap.c has
+been substantially refactored upstream (accessor functions instead of direct
+struct field access, perf_cpu_map__merge()'s signature changed). Original
+patch no longer applied due to context drift; same fix (loop/size counters
+as unsigned, avoiding gcc -Werror=alloc-size-larger-than= on the malloc(3)
+call) reapplied to the new code.
 
-diff --git a/tools/lib/perf/cpumap.c b/tools/lib/perf/cpumap.c
-index 6cd0be7c1bb4..d960880dd903 100644
+Upstream-Status: Submitted [https://lore.kernel.org/linux-perf-users/20230123211310.127532-1-raj.khem@gmail.com/T/#u]
+Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>
+
 --- a/tools/lib/perf/cpumap.c
 +++ b/tools/lib/perf/cpumap.c
-@@ -351,8 +351,8 @@ struct perf_cpu_map *perf_cpu_map__merge(struct perf_cpu_map *orig,
- 					 struct perf_cpu_map *other)
+@@ -408,8 +408,8 @@
+ int perf_cpu_map__merge(struct perf_cpu_map **orig, struct perf_cpu_map *other)
  {
  	struct perf_cpu *tmp_cpus;
 -	int tmp_len;
@@ -41,29 +42,46 @@ index 6cd0be7c1bb4..d960880dd903 100644
 +	unsigned int i, j, k;
  	struct perf_cpu_map *merged;
  
- 	if (perf_cpu_map__is_subset(orig, other))
-@@ -369,7 +369,7 @@ struct perf_cpu_map *perf_cpu_map__merge(struct perf_cpu_map *orig,
+ 	if (perf_cpu_map__is_subset(*orig, other))
+@@ -427,7 +427,7 @@
  
  	/* Standard merge algorithm from wikipedia */
  	i = j = k = 0;
--	while (i < orig->nr && j < other->nr) {
-+	while (i < (unsigned int)orig->nr && j < (unsigned int)other->nr) {
- 		if (orig->map[i].cpu <= other->map[j].cpu) {
- 			if (orig->map[i].cpu == other->map[j].cpu)
+-	while (i < __perf_cpu_map__nr(*orig) && j < __perf_cpu_map__nr(other)) {
++	while (i < (unsigned int)__perf_cpu_map__nr(*orig) && j < (unsigned int)__perf_cpu_map__nr(other)) {
+ 		if (__perf_cpu_map__cpu(*orig, i).cpu <= __perf_cpu_map__cpu(other, j).cpu) {
+ 			if (__perf_cpu_map__cpu(*orig, i).cpu == __perf_cpu_map__cpu(other, j).cpu)
  				j++;
-@@ -378,10 +378,10 @@ struct perf_cpu_map *perf_cpu_map__merge(struct perf_cpu_map *orig,
- 			tmp_cpus[k++] = other->map[j++];
+@@ -436,10 +436,10 @@
+ 			tmp_cpus[k++] = __perf_cpu_map__cpu(other, j++);
  	}
  
--	while (i < orig->nr)
-+	while (i < (unsigned int)orig->nr)
- 		tmp_cpus[k++] = orig->map[i++];
+-	while (i < __perf_cpu_map__nr(*orig))
++	while (i < (unsigned int)__perf_cpu_map__nr(*orig))
+ 		tmp_cpus[k++] = __perf_cpu_map__cpu(*orig, i++);
  
--	while (j < other->nr)
-+	while (j < (unsigned int)other->nr)
- 		tmp_cpus[k++] = other->map[j++];
+-	while (j < __perf_cpu_map__nr(other))
++	while (j < (unsigned int)__perf_cpu_map__nr(other))
+ 		tmp_cpus[k++] = __perf_cpu_map__cpu(other, j++);
  	assert(k <= tmp_len);
  
--- 
-2.39.1
-
+@@ -454,8 +454,8 @@
+ 					     struct perf_cpu_map *other)
+ {
+ 	struct perf_cpu *tmp_cpus;
+-	int tmp_len;
+-	int i, j, k;
++	unsigned int tmp_len;
++	unsigned int i, j, k;
+ 	struct perf_cpu_map *merged = NULL;
+ 
+ 	if (perf_cpu_map__is_subset(other, orig))
+@@ -469,7 +469,7 @@
+ 		return NULL;
+ 
+ 	i = j = k = 0;
+-	while (i < __perf_cpu_map__nr(orig) && j < __perf_cpu_map__nr(other)) {
++	while (i < (unsigned int)__perf_cpu_map__nr(orig) && j < (unsigned int)__perf_cpu_map__nr(other)) {
+ 		if (__perf_cpu_map__cpu(orig, i).cpu < __perf_cpu_map__cpu(other, j).cpu)
+ 			i++;
+ 		else if (__perf_cpu_map__cpu(orig, i).cpu > __perf_cpu_map__cpu(other, j).cpu)


### PR DESCRIPTION
# Description

I only want to build `core-image-full-cmdline` for a tutorial I'm working with. I only have access to the hardware of `visionfive` so this is what I used. At first the build failed, and then the boot failed, so I kinda made it build and boot.

## Checklist

- [x] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [x] I have tested this change (provide brief details below)
- [ ] Documentation has been added/updated where necessary in the README and `docs/`
- [x] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [x] I have added my `Signed-off-by` and any other tags to each commit

# How has this been tested?

Provide a brief summary here (e.g. build only, build + boot test, something more
specific). Boot logs, images, or other artifacts are especially helpful.

```
OpenSBI v1.0
   ____                    _____ ____ _____
  / __ \                  / ____|  _ \_   _|
 | |  | |_ __   ___ _ __ | (___ | |_) || |
 | |  | | '_ \ / _ \ '_ \ \___ \|  _ < | |
 | |__| | |_) |  __/ | | |____) | |_) || |_
  \____/| .__/ \___|_| |_|_____/|____/_____|
        | |
        |_|

fdt_reset_driver_init: gpio-restart init failed, -1001
Platform Name             : StarFive VisionFive V1
(...)
U-Boot 2022.04-rc2-VisionFive (Mar 07 2022 - 21:12:22 +0800)StarFive

CPU:   rv64imafdc
Model: StarFive VisionFive V1
DRAM:  8 GiB
Core:  13 devices, 9 uclasses, devicetree: separate
MMC:   mmc@10000000: 0, mmc@10010000: 1
Loading Environment from SPIFlash... cadence_spi spi@11860000: Can't get reset: -524
SF: Detected gd25lq128 with page size 256 Bytes, erase size 4 KiB, total 16 MiB
*** Warning - bad CRC, using default environment

StarFive EEPROM format v1

--------EEPROM INFO--------
Vendor : StarFive Technology Co., Ltd.
Product full SN: VF7100A1-2209-D008E000-00000556
data version: 0x1
PCB revision: 0x1
BOM revision: A
Ethernet MAC address: 6c:cf:39:00:05:55
(...)
Importing environment from mmc0 ...
** Invalid partition 3 **
Couldn't find partition mmc 0:3
Can't set block device
Autoboot in 2 seconds
21867008 bytes read in 4542 ms (4.6 MiB/s)
28476 bytes read in 27 ms (1 MiB/s)
Moving Image from 0x84000000 to 0x80200000, end=81735000
## Flattened Device Tree blob at 88000000
   Booting using the fdt blob at 0x88000000
   Using Device Tree in place at 0000000088000000, end 0000000088009f3b

Starting kernel ...

Booting Linux on hartid 0
Linux version 6.17.0-visionfive-g7f7930f9a3cf (oe-user@oe-host) (riscv64-oe-linux-gcc (GCC) 16.1.0, GNU ld (GNU Binutils) 2.46.1) #1 SMP Thu Oct  9 14:57:14 UTC 2025
Machine model: StarFive VisionFive V1
SBI specification v0.3 detected
SBI implementation ID=0x1 Version=0x10000
SBI TIME extension detected
SBI IPI extension detected
SBI RFENCE extension detected
earlycon: uart0 at MMIO32 0x0000000012440000 (options '115200n8')
printk: legacy bootconsole [uart0] enabled

(...)
Welcome to OpenEmbedded nodistro.0!
```
