### PR TITLE
rtl8723ds: update to latest upstream revision

### DIFF
--- a/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
+++ b/recipes-kernel/rtl8723ds-mod/rtl8723ds.bb
@@ -7,7 +7,7 @@ inherit module
 KCFLAGS = "-fno-asynchronous-unwind-tables -fno-unwind-tables"
 KCFLAGS[export] = "1"
 
-SRCREV = "ec85dc6b9f72bfe413bff464ed01a272e29c8dbe"
+SRCREV = "52e593e8c889b68ba58bd51cbdbcad7fe71362e4"
 
 SRC_URI = " \
           git://github.com/lwfinger/rtl8723ds.git;protocol=https;name=rtl8723ds;branch=master \


### PR DESCRIPTION
rtl8723ds: bump to newer upstream rev with cfg80211 on kernel 6.7 beacon API fix.

# Description

The current recipe no longer builds against Linux 6.7 and later due to
changes to the cfg80211 beacon API. The newer upstream rtl8723ds
revision already includes the required compatibility fixes.
Bumped to commit: [52e593e8c889b68ba58bd51cbdbcad7fe71362e4](https://github.com/lwfinger/rtl8723ds/commit/52e593e8c889b68ba58bd51cbdbcad7fe71362e4)

## Checklist

- [x] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [x] I have tested this change (provide brief details below)
- [ ] Documentation has been added/updated where necessary in the README and `docs/`
- [ ] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [x] I have added my `Signed-off-by` and any other tags to each commit

*Note: unchecked items above are N/A — this is a recipe version bump, not a BSP addition/modification.*

# How has this been tested?

This change was tested on:

- Linux 6.12.34 (linux-imx from meta-imx)
- NXP i.MX93 platform

Verified at runtime:
- Recipe builds successfully
- Module loads successfully
- Wireless scanning using iwd
- Association using iwd
- IPv4 address obtained via DHCP using udhcpc
