### PR TITLE
u-boot: fix k1 SRC_URI

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -29,8 +29,7 @@ SRC_URI:append:freedom-u540 = " \
            "
 SRC_URI:append:freedom-u540_sota = " file://uEnv.txt"
 
-SRC_URI:k1 = " \
-            git://source.denx.de/u-boot/u-boot.git;protocol=https;branch=master \
+SRC_URI:append:k1 = " \
             file://bootcommand.cfg \
             "
 


### PR DESCRIPTION
# Description

Remove the repository URL from the SRC_URI line for K1 boards, so that we use the same mirror as oe-core for u-boot. This allows a patch[1] from oe-core to be applied for Python 3 compatibility in pylibfdt. Otherwise, we run into errors at the do_compile step:

```
|scripts/dtc/pylibfdt/libfdt_wrap.c:6733:17: error: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
| 6733 |       resultobj = PyString_FromString(
|      |                 ^
|scripts/dtc/pylibfdt/libfdt_wrap.c:6796:17: error: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
| 6796 |       resultobj = PyString_FromString(
|      |                 ^
|scripts/dtc/pylibfdt/libfdt_wrap.c:6861:17: error: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
| 6861 |       resultobj = PyString_FromString(
|      |                 ^
|error: Command '['gcc', ..., '-c', 'scripts/dtc/pylibfdt/libfdt_wrap.c', '-o', 'build/temp.linux-x86_64-cpython-314/scripts/dtc/pylibfdt/libfdt_wrap.o']' returned non-zero exit status 1.
|make[3]: *** [.../scripts/dtc/pylibfdt/Makefile:33: rebuild] Error 1
|make[2]: *** [.../scripts/Makefile.build:497: scripts/dtc/pylibfdt] Error 2
|make[1]: *** [.../Makefile:2403: scripts_dtc] Error 2
|make: *** [Makefile:189: __sub-make] Error 2
|ERROR: oe_runmake failed
```

[1]: https://git.openembedded.org/openembedded-core/commit/?id=299a82a9c909b73a9b93877d6c1b381ec8f83b04

## Checklist

- [X] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [X] I have tested this change (provide brief details below)
- [ ] Documentation has been added/updated where necessary in the README and `docs/`
- [ ] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [X] I have added my `Signed-off-by` and any other tags to each commit

# How has this been tested?

Build and boot test on BayLibre Forgejo: https://forgejo.baylibre.com/tgamblin/boardgarden/actions/runs/227/jobs/3/attempt/1 (mainly the `bananapi-f3` case - the others test initramfs boot over tftp)