### PR TITLE
linux-mainline-k1: use 7.2 kernel version

### DIFF
--- a/recipes-kernel/linux/linux-mainline-k1.bb
+++ b/recipes-kernel/linux/linux-mainline-k1.bb
@@ -17,7 +17,7 @@ SRC_URI:append:bananapi-cm6-io = " \
            file://0003-riscv-dts-spacemit-k1-Add-Banana-Pi-BPI-CM6-IO-board.patch \
           "
 
-SRCREV = "f5098b6bae761e346ebcd9da7f95622c04733cff"
-LINUX_VERSION = "7.2-rc5"
+SRCREV = "8d3ae59288f1e7d58d76558a6ee96d533bc5019f"
+LINUX_VERSION = "7.2"
 
 COMPATIBLE_MACHINE = "(k1)"


### PR DESCRIPTION
# Description

Linux 7.2 has released, so we can drop the rc kernel version for the K1 mainline recipe.

## Checklist

- [X] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [X] I have tested this change (provide brief details below)
- [ ] Documentation has been added/updated where necessary in the README and `docs/`
- [ ] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [X] I have added my `Signed-off-by` and any other tags to each commit

# How has this been tested?

Test workflow (queued): https://forgejo.baylibre.com/tgamblin/boardgarden/actions/runs/239/jobs/0/attempt/1