### PR TITLE
linux-k3: update SRCREV to point at latest

### DIFF
--- a/recipes-kernel/linux/linux-k3.bb
+++ b/recipes-kernel/linux/linux-k3.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
         file://0001-gcc-plugins-Always-define-CONST_CAST_GIMPLE-and-CONS.patch \
 	"
 
-SRCREV = "0ffac20d9ef93c572b649037213bbe20ef59a714"
+SRCREV = "4158237f35b8fd62ba198c1627e5a66e5a34c50f"
 
 KCONFIG_MODE = "alldefconfig"
 KBUILD_DEFCONFIG = "k3_bianbu_defconfig"


### PR DESCRIPTION
# Description

Update SRCREV so that we build with the latest K3 vendor kernel (6.18) tree. This pulls in many fixes, notably:

- ed50ab552a04 (remoteproc: spacemit: fix load access fault in get_loaded_rsc_table)
- a7855ec07120 (k3: Modify the memory layout to reduce the number of PMP entries consumed by the AP side.)

Without these, even a basic initramfs boot fails with errors like:

|[    0.000000] OF: reserved mem: OVERLAP DETECTED!
|[    0.000000] mmode_resv3@1,200000 (0x0000000100200000--0x0000000100400000) overlaps with rcpu0_pwr@100200000 (0x0000000100200000--0x0000000100500000)
|[    0.000000] OF: reserved mem: OVERLAP DETECTED!
|[    0.000000] rcpu0_pwr@100200000 (0x0000000100200000--0x0000000100500000) overlaps with mmode_resv4@1,400000 (0x0000000100400000--0x0000000100600000)
|[    0.000000] OF: reserved mem: OVERLAP DETECTED!
|[    0.000000] mmode_resv4@1,400000 (0x0000000100400000--0x0000000100600000) overlaps with rcpu0_heap@100500000 (0x0000000100500000--0x0000000100700000)
|[    0.000000] OF: reserved mem: OVERLAP DETECTED!
|[    0.000000] rcpu1_runtime@100800000 (0x0000000100800000--0x0000000100b00000) overlaps with mmode_resv5@1,800000 (0x0000000100800000--0x0000000100c00000)
|[    0.000000] OF: reserved mem: OVERLAP DETECTED!
|[    0.000000] mmode_resv5@1,800000 (0x0000000100800000--0x0000000100c00000) overlaps with rcpu1_heap@100B00000 (0x0000000100b00000--0x0000000100d00000)
|[    0.000000] OF: reserved mem: OVERLAP DETECTED!
|[    0.000000] vdev0buffer@100d00000 (0x0000000100d00000--0x0000000100dfc000) overlaps with mmode_resv2@1,d00000 (0x0000000100d00000--0x0000000100e00000)
|[    0.000000] OF: reserved mem: OVERLAP DETECTED!
|[    0.000000] mmode_resv2@1,d00000 (0x0000000100d00000--0x0000000100e00000) overlaps with rcpu1_rsc_table@100dfc000 (0x0000000100dfc000--0x0000000100e00000)

and:

|[    1.658969] usbhid: USB HID core driver
|[    1.667168] scsi 0:0:0:0: Direct-Access     KINGSTON TY7B-128         0004 PQ: 0 ANSI: 6
|[    1.686250] ufshcd-spacemit c0e00000.ufshc: lu 0 scsi queue depth limited to 1
|[    1.686616] riscv-sbi-mpxy-mbox soc:mpxy_mbox@0: mailbox registered with 5 channels
|[    1.698475] sd 0:0:0:0: [sda] 31266816 4096-byte logical blocks: (128 GB/119 GiB)
|[    1.702629] remoteproc remoteproc0: rcpu_rproc1 is available
|[    1.708683] sd 0:0:0:0: [sda] Write Protect is off
|[    1.714200] remoteproc remoteproc0: attaching to rcpu_rproc1
|[    1.718953] sd 0:0:0:0: [sda] Mode Sense: 00 32 00 10
|[    1.724638] Oops - load access fault [#1]
|[    1.724641] Modules linked in:
|[    1.724646] CPU: 5 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.18.3-k3 #1 PREEMPT(voluntary)
|[    1.724651] Hardware name: SpacemiT K3 Pico ITX (DT)
|[    1.724653] epc : __memcpy+0x3c/0xf8
|[    1.724661]  ra : kmemdup_noprof+0x2e/0x48
|[    1.724666] epc : ffffffff80f6b93c ra : ffffffff8027ea72 sp : ffffffc600083a90
|...
|[    1.724691] status: 0000000200000120 badaddr: ffffffc600f78000 cause: 0000000000000005
|[    1.724694] [<ffffffff80f6b93c>] __memcpy+0x3c/0xf8
|[    1.724698] [<ffffffff80c296cc>] rproc_boot+0x300/0x40c
|[    1.724702] [<ffffffff80c298ec>] rproc_add+0xe8/0x1b8
|[    1.724705] [<ffffffff80c299d2>] devm_rproc_add+0x16/0x74
|[    1.724708] [<ffffffff80c2de20>] spacemit_rproc_probe+0x134/0x1e4
|[    1.724712] [<ffffffff808a2ab6>] platform_probe+0x66/0xa4
|[    1.724716] [<ffffffff8089f782>] really_probe+0x8a/0x318
|...
|[    1.724750] [<ffffffff810464a6>] spacemit_rproc_driver_init+0x1a/0x28
|[    1.724754] [<ffffffff80021906>] do_one_initcall+0x4e/0x274
|[    1.724758] [<ffffffff81001784>] kernel_init_freeable+0x23c/0x2c0
|[    1.724763] [<ffffffff80f6deb2>] kernel_init+0x1e/0x16c
|[    1.724766] [<ffffffff80023716>] ret_from_fork_kernel+0xe/0xf0
|[    1.724770] [<ffffffff80f7a18e>] ret_from_fork_kernel_asm+0x16/0x18
|[    1.724776] Code: 00ff 0f85 eae3 fed5 8e19 7713 f806 c759 86b3 00e5 (6198) 659c
|[    1.724781] ---[ end trace 0000000000000000 ]---
|[    1.724784] Kernel panic - not syncing: Fatal exception in interrupt
|[    1.724786] SMP: stopping secondary CPUs
|[    1.983530] ---[ end Kernel panic - not syncing: Fatal exception in interrupt ]---

## Checklist

- [X] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [X] I have tested this change (provide brief details below)
- [ ] Documentation has been added/updated where necessary in the README and `docs/`
- [ ] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [X] I have added my `Signed-off-by` and any other tags to each commit

# How has this been tested?

Booted Yocto-built initramfs and K3 kernel on K3 Pico-ITX: https://forgejo.baylibre.com/tgamblin/boardgarden/actions/runs/315/jobs/0/attempt/1

Once this PR is merged, I'll have the K3 Pico-ITX doing a nightly initramfs boot test, so we should catch any future issues related to the kernel at that level.
