### PR TITLE
u-boot-spl-spacemit: set EXTRA_OEMAKE for openssl 4.x

### DIFF
--- a/recipes-bsp/u-boot/u-boot-spl-spacemit.inc
+++ b/recipes-bsp/u-boot/u-boot-spl-spacemit.inc
@@ -15,6 +15,7 @@ EXTRA_OEMAKE = "\
     HOSTCC='${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}' \
     HOSTCXX='${BUILD_CXX}' \
 "
+EXTRA_OEMAKE:append = " HOSTCFLAGS_rsa-sign.o=-DOPENSSL_ENGINE_STUBS -Wno-deprecated-declarations"
 
 do_configure() {
 	oe_runmake ${UBOOT_SPL_MACHINE}


### PR DESCRIPTION
# Description

OpenSSL was upgraded to 4.0.1 in oe-core commit `20bf704e58`. This removes engine support and the ENGINE API, starting in openssl commit `5ef339776d`, where if `OPENSSL_ENGINE_STUBS` is defined the relevant engine macros are set to 0. This change breaks u-boot-spl-k1 and u-boot-spl-k3 on the do_compile step, so modify EXTRA_OEMAKE to set `HOSTCFLAGS_rsa-sign.o` (found in U-Boot's `tools/Makefile`) to generate the stubs. The `-Wno-deprecated-declarations` flag seems to be mainly for OS X, but preserve it anyway to minimize the scope of our change.

## Checklist

- [x] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [x] I have tested this change (provide brief details below)
- [ ] Documentation has been added/updated where necessary in the README and `docs/`
- [ ] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [X] I have added my `Signed-off-by` and any other tags to each commit

# How has this been tested?

Built for the `bananapi-f3` locally. Running a test in CI here: https://forgejo.baylibre.com/tgamblin/boardgarden/actions/runs/374/jobs/3/attempt/1
