### PR TITLE
u-boot-k3: set EXTRA_OEMAKE for openssl 4.x

### DIFF
--- a/recipes-bsp/u-boot/u-boot-k3_2022.10.bb
+++ b/recipes-bsp/u-boot/u-boot-k3_2022.10.bb
@@ -22,6 +22,8 @@ UBOOT_MAKE_TARGET = "all"
 SPL_BINARY = ""
 UBOOT_ENV = ""
 
+EXTRA_OEMAKE:append = " HOSTCFLAGS_rsa-sign.o=-DOPENSSL_ENGINE_STUBS -Wno-deprecated-declarations"
+
 do_deploy:append() {
     # cmd_build_itb in config.mk fails silently for out-of-tree builds (srctree/objtree mismatch).
     # Build u-boot.itb here instead, where make all has completed and ${B} is fully populated.


### PR DESCRIPTION
# Description

I missed this with the previous fix for the K1 boards. Below is the commit description.

OpenSSL was upgraded to 4.0.1 in oe-core commit 20bf704e58. This removes engine support and the ENGINE API, starting in openssl commit 5ef339776d, where if OPENSSL_ENGINE_STUBS is defined the relevant engine macros are set to 0. As with commit 666c8f7, this change breaks u-boot-k3 on the do_compile step, so modify EXTRA_OEMAKE to set HOSTCFLAGS_rsa-sign.o (found in U-Boot's tools/Makefile) to generate the stubs. The '-Wno-deprecated-declarations' flag seems to be mainly for OS X, but preserve it anyway to minimize the scope of our change.

## Checklist

- [X] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [X] I have tested this change (provide brief details below)
- [ ] Documentation has been added/updated where necessary in the README and `docs/`
- [ ] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [X] I have added my `Signed-off-by` and any other tags to each commit

# How has this been tested?

Provide a brief summary here (e.g. build only, build + boot test, something more
specific). Boot logs, images, or other artifacts are especially helpful.

Local test of a u-boot-k3 build. Also running against my CI: https://forgejo.baylibre.com/tgamblin/boardgarden/actions/runs/388/jobs/0/attempt/1