### PR TITLE
docs: k1: no longer need to manually copy bootinfo_sd.bin

### DIFF
--- a/docs/bananapi-cm6-io.md
+++ b/docs/bananapi-cm6-io.md
@@ -72,12 +72,6 @@ Flash `core-image-full-cmdline-bananapi-cm6-io.rootfs.wic.gz` onto a uSD card (a
 $ sudo bmaptool copy build/tmp/deploy/images/bananapi-cm6-io/core-image-full-cmdline-bananapi-cm6-io.rootfs.wic.gz /dev/sdx
 ```
 
-Then, you also need to flash the `bootinfo_sd.bin` file at the very beginning of the SD card (not part of the WIC image yet):
-
-```
-$ sudo dd if=build/tmp/deploy/images/bananapi-cm6-io/bootinfo_sd.bin of=/dev/sdx
-```
-
 Boot the Board
 ==============
 

--- a/docs/bananapi-f3.md
+++ b/docs/bananapi-f3.md
@@ -69,12 +69,6 @@ Flash `core-image-full-cmdline-bananapi-f3.rootfs.wic.gz` onto a uSD card (assum
 $ sudo bmaptool copy build/tmp/deploy/images/bananapi-f3/core-image-full-cmdline-bananapi-f3.rootfs.wic.gz /dev/sdx
 ```
 
-Then, you also need to flash the `bootinfo_sd.bin` file at the very beginning of the SD card (not part of the WIC image yet):
-
-```
-$ sudo dd if=build/tmp/deploy/images/bananapi-f3/bootinfo_sd.bin of=/dev/sdx
-```
-
 Boot the Board
 ==============
 

--- a/docs/orangepi-rv2.md
+++ b/docs/orangepi-rv2.md
@@ -69,12 +69,6 @@ Flash `core-image-full-cmdline-orangepi-rv2.rootfs.wic.gz` onto a uSD card (assu
 $ sudo bmaptool copy build/tmp/deploy/images/orangepi-rv2/core-image-full-cmdline-orangepi-rv2.rootfs.wic.gz /dev/sdx
 ```
 
-Then, you also need to flash the `bootinfo_sd.bin` file at the very beginning of the SD card (not part of the WIC image yet):
-
-```
-$ sudo dd if=build/tmp/deploy/images/orangepi-rv2/bootinfo_sd.bin of=/dev/sdx
-```
-
 Boot the Board
 ==============
 


### PR DESCRIPTION
# Description

This simplifies documentation for K1 based boards by removing a no longer necessary step.
Copy bootinfo_sd.bin at the beginning of the image is now taken care of by the "k1-image" class.

## Checklist

- [ x] I have read and understood the [Contributing Changes to a Component](https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html) and [Recipe Style Guide](https://docs.yoctoproject.org/dev/contributor-guide/recipe-style-guide.html#patch-upstream-status) sections in the Yocto Project documentation
- [x ] I have tested this change (provide brief details below)
- [x ] Documentation has been added/updated where necessary in the README and `docs/`
- [ ] If the change is to a BSP in
  [DEPRECATED.md](https://github.com/riscv/meta-riscv/blob/master/DEPRECATED.md),
  then it is maintenance-only, i.e. it does not add support for a
  previously-removed BSP (or significant features to one slated for removal)
- [ ] (For new/modified BSPs) I have added relevant information in the README [table](https://github.com/riscv/meta-riscv/tree/master?tab=readme-ov-file#available-machines)
- [ ] (For new/modified BSPs) The bitbake-setup templates in `bitbake-registry/`
  have been updated, if necessary
- [ ] (For new/modified BSPs) A `kas` file has been provided in `kas/`
- [ x] I have added my `Signed-off-by` and any other tags to each commit

# How has this been tested?

This has been tested on the "orangepi-rv2" machine.
This should work the same on bananapi-f3 and bananapi-cm6-io which share the same SpacemiT K1 SoC.
